### PR TITLE
1.增加split判断，hash分片的要在balance窗口才回去尝试split，不影响统计chunksize；2.增加一些慢查日志和re…

### DIFF
--- a/src/mongo/executor/remote_command_request.h
+++ b/src/mongo/executor/remote_command_request.h
@@ -115,6 +115,8 @@ struct RemoteCommandRequest {
 
     // Deadline by when the request must be completed
     Date_t expirationDate = kNoExpirationDate;
+    //single RemoteCommond start time
+    Date_t start_time;
 };
 
 }  // namespace executor

--- a/src/mongo/s/balancer_configuration.h
+++ b/src/mongo/s/balancer_configuration.h
@@ -93,6 +93,11 @@ public:
      */
     bool isTimeInBalancingWindow(const boost::posix_time::ptime& now) const;
 
+     /**
+     * Returns true if either 'now' is in the autosplit window.Only use hashed 
+     */
+    bool isTimeInAutoSplitWindow(const boost::posix_time::ptime& now) const;
+
     /**
      * Returns the secondary throttle options.
      */
@@ -107,6 +112,11 @@ public:
         return _waitForDelete;
     }
 
+protected:
+    boost::optional<boost::posix_time::ptime> getActiveSplitStart(){
+        return _activeSplitStart;
+    }
+
 private:
     BalancerSettingsType();
 
@@ -114,10 +124,23 @@ private:
 
     boost::optional<boost::posix_time::ptime> _activeWindowStart;
     boost::optional<boost::posix_time::ptime> _activeWindowStop;
+    boost::optional<boost::posix_time::ptime> _activeSplitStart;
 
     MigrationSecondaryThrottleOptions _secondaryThrottle;
 
     bool _waitForDelete{false};
+//for balancer_configuration_test use
+public:
+    int getRandMinutes(){
+        return _rand_minutes;
+    }
+
+    int getRandSeconds(){
+        return _rand_seconds;
+    }
+private:
+    int _rand_minutes = 0;
+    int _rand_seconds = 0;
 };
 
 /**
@@ -222,6 +245,8 @@ public:
      */
     bool shouldBalance() const;
     bool shouldBalanceForAutoSplit() const;
+
+    bool shouldSplitNow() const;
 
     /**
      * Returns the secondary throttle options for the balancer.

--- a/src/mongo/s/catalog_cache.cpp
+++ b/src/mongo/s/catalog_cache.cpp
@@ -99,6 +99,7 @@ std::shared_ptr<ChunkManager> refreshCollectionRoutingInfo(
 
     ChunkVersion collectionVersion = startingCollectionVersion;
 
+    Timer timer;
     for (const auto& chunk : collectionAndChunks.changedChunks) {
         const auto& chunkVersion = chunk.getVersion();
 
@@ -129,7 +130,7 @@ std::shared_ptr<ChunkManager> refreshCollectionRoutingInfo(
         // Insert only the chunk itself
         chunkMap.insert(std::make_pair(chunk.getMax(), std::make_shared<Chunk>(chunk)));
     }
-
+    log()<<"compare diff chunks size="<<collectionAndChunks.changedChunks.size()<<",optime="<<timer.millis();
     // If at least one diff was applied, the metadata is correct, but it might not have changed so
     // in this case there is no need to recreate the chunk manager.
     //

--- a/src/mongo/s/commands/cluster_write.cpp
+++ b/src/mongo/s/commands/cluster_write.cpp
@@ -351,6 +351,12 @@ void updateChunkWriteStatsAndSplitIfNeeded(OperationContext* opCtx,
             return;
         }
 
+        if(manager->getShardKeyPattern().isHashedPattern()){//hash分片
+            if(!balancerConfig->shouldBalanceForAutoSplit()){//balance窗口，两个if不要合并，因为range的split要保持正常
+                return;
+            }
+        }
+
         LOG(1) << "about to initiate autosplit: " << redact(chunk->toString())
                << " dataWritten: " << chunkBytesWritten << " splitThreshold: " << splitThreshold;
 

--- a/src/mongo/s/config_server_catalog_cache_loader.cpp
+++ b/src/mongo/s/config_server_catalog_cache_loader.cpp
@@ -25,7 +25,7 @@
  *    exception statement from all source files in the program, then also delete
  *    it in the license file.
  */
-
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kSharding
 #include "mongo/platform/basic.h"
 
 #include "mongo/s/config_server_catalog_cache_loader.h"
@@ -35,6 +35,7 @@
 #include "mongo/s/catalog/sharding_catalog_client.h"
 #include "mongo/s/grid.h"
 #include "mongo/stdx/memory.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -109,6 +110,8 @@ CollectionAndChangedChunks getChangedChunks(OperationContext* opCtx,
     // Query the chunks which have changed
     std::vector<ChunkType> changedChunks;
     repl::OpTime opTime;
+    log()<< "diffQuery.query=" << diffQuery.query.toString() << ";diffQuery.sort=" << diffQuery.sort.toString();
+
     uassertStatusOK(Grid::get(opCtx)->catalogClient(opCtx)->getChunks(
         opCtx,
         diffQuery.query,


### PR DESCRIPTION
变更背景
1.hash分片mongo集群 mongos split触发放在balance时间窗口，避免高峰期抖动
2.rs使用的命令增加慢查询日志，以slowMs为判断标准
3.一些环节增加了耗时日志

