### PR TITLE
KODO-14527 去掉心跳同步的模块

### DIFF
--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -715,7 +715,7 @@ serveronlyLibdeps = [
     "$BUILD_DIR/mongo/s/coreshard",
     "$BUILD_DIR/mongo/s/shard_id",
     "$BUILD_DIR/mongo/s/serveronly",
-    "$BUILD_DIR/mongo/db/s/refresh_secondary_routing",
+    # "$BUILD_DIR/mongo/db/s/refresh_secondary_routing",
     "$BUILD_DIR/mongo/db/s/init_router_info_for_mongod",
     "$BUILD_DIR/mongo/db/s/refresh_metainfo",
     "$BUILD_DIR/mongo/db/s/auto_refresh_routing",

--- a/src/mongo/db/commands/parameters.cpp
+++ b/src/mongo/db/commands/parameters.cpp
@@ -41,6 +41,7 @@
 #include "mongo/db/auth/internal_user_auth.h"
 #include "mongo/db/commands.h"
 #include "mongo/db/server_parameters.h"
+#include "mongo/db/server_options.h"
 #include "mongo/db/storage/storage_options.h"
 #include "mongo/logger/logger.h"
 #include "mongo/logger/parse_log_component_settings.h"
@@ -277,6 +278,40 @@ public:
         return Status::OK();
     }
 } logLevelSetting;
+
+class SecondaryRouterSwitch : public ServerParameter {
+    MONGO_DISALLOW_COPYING(SecondaryRouterSwitch);
+    public:
+    SecondaryRouterSwitch() : ServerParameter(ServerParameterSet::getGlobal(), "secondaryRouteSwitch", true, true) {}
+
+    virtual void append(OperationContext* txn, BSONObjBuilder& b, const std::string& name) {
+        b << name << serverGlobalParams.secondaryRouteSwitch.load();
+    }
+
+    virtual Status set(const BSONElement& newValueElement) {
+        bool newValue;
+        if (!newValueElement.coerce(&newValue))
+            return Status(ErrorCodes::BadValue,
+                          mongoutils::str::stream() << "Invalid value for secondaryRouteSwitch: "
+                                                    << newValueElement);
+        serverGlobalParams.secondaryRouteSwitch = newValue;
+        return Status::OK();
+    }
+
+    virtual Status setFromString(const std::string& str) {
+        bool newValue;
+        if (str == "true") {
+            newValue = true;
+        } else if (str == "false") {
+            newValue = false;
+        } else {
+            return Status(ErrorCodes::BadValue,
+                          mongoutils::str::stream() << "Invalid value for secondaryRouteSwitch: " << str);
+        }
+        serverGlobalParams.secondaryRouteSwitch = newValue;
+        return Status::OK();
+    }
+} secondaryRouterSwitch;
 
 /**
  * Log component verbosity.

--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -93,7 +93,6 @@
 #include "mongo/db/s/balancer/balancer.h"
 #include "mongo/db/s/sharding_initialization_mongod.h"
 #include "mongo/db/s/sharding_state.h"
-#include "mongo/db/s/refresh_secondary_routing.h"
 #include "mongo/db/s/sharding_state_recovery.h"
 #include "mongo/db/s/type_shard_identity.h"
 #include "mongo/db/server_options.h"
@@ -147,7 +146,7 @@
 #include "mongo/util/time_support.h"
 #include "mongo/util/version.h"
 #include "mongo/db/s/auto_refresh_routing.h"
-#include "mongo/db/s/refresh_metainfo.h"
+// #include "mongo/db/s/refresh_metainfo.h"
 #include "mongo/db/watchdog_mongod.h"
 
 #ifdef MONGO_CONFIG_SSL
@@ -779,7 +778,8 @@ ExitCode _initAndListen(int listenPort) {
                             ->initializeShardingAwarenessIfNeeded(startupOpCtx.get()));
     if (shardingInitialized) {
         reloadShardRegistryUntilSuccess(startupOpCtx.get());
-        //static AutoRefreshRouting task = AutoRefreshRouting(0);
+        static AutoRefreshRouting task = AutoRefreshRouting(0);
+
         {
             log() << "[MongoStat] init sharding router info, but only run once";
             initShardingMetaInfos(startupOpCtx.get(), ClusterRole::ShardServer);
@@ -787,11 +787,6 @@ ExitCode _initAndListen(int listenPort) {
     } else {
         log() << "shardingInitialize failed, not starting sharding";
     }
-
-    log() << "starting refresh secondary Routing";
-    refreshSecondaryRoutingJob.go();
-    log() << "starting refresh config server metainfo";
-    refreshMetaInfoJob.go();
 
     if (!storageGlobalParams.readOnly) {
         logStartup(startupOpCtx.get());

--- a/src/mongo/db/repl/SConscript
+++ b/src/mongo/db/repl/SConscript
@@ -365,7 +365,7 @@ env.Library('topology_coordinator_impl',
                 '$BUILD_DIR/mongo/util/fail_point',
                 '$BUILD_DIR/mongo/db/s/sharding',
                 '$BUILD_DIR/mongo/db/stats/apcounter',
-                '$BUILD_DIR/mongo/db/s/refresh_secondary_routing',    
+                # '$BUILD_DIR/mongo/db/s/refresh_secondary_routing',    
             ])
 
 env.CppUnitTest('repl_set_heartbeat_response_test',

--- a/src/mongo/db/repl/member_heartbeat_data.h
+++ b/src/mongo/db/repl/member_heartbeat_data.h
@@ -134,10 +134,6 @@ public:
         return _updatedSinceRestart;
     }
 
-    std::map<std::string, std::shared_ptr<ChunkVersion>> getAllShardVersions() const {
-        return _lastResponse.getNsShardVersions();
-    }
-
 private:
     // -1 = not checked yet, 0 = member is down/unreachable, 1 = member is up
     int _health;

--- a/src/mongo/db/repl/repl_set_heartbeat_response.cpp
+++ b/src/mongo/db/repl/repl_set_heartbeat_response.cpp
@@ -41,7 +41,6 @@
 #include "mongo/util/assert_util.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
-#include "mongo/db/stats/apcounter.h"
 
 namespace mongo {
 namespace repl {
@@ -68,18 +67,6 @@ const std::string kSyncSourceFieldName = "syncingTo";
 const std::string kTermFieldName = "term";
 const std::string kTimeFieldName = "time";
 const std::string kTimestampFieldName = "ts";
-
-
-/** 用来触发secondary来更新元数据，只有当前的node是primary的情况下才会带有这个信息，而节点也只会因为接受到的是primary的情况下来分析这个字段;
-* 如果接受到的是非primary的心跳信息就不会分析这个字段;
-* 字段的样式会是这样:
-* {
-    "mock.smy": chunkversion,
-    "mock.smy2": chunkversion
-}
-*/
-const std::string kNsShardVersions = "nsShardVersions";
-
 }  // namespace
 
 void ReplSetHeartbeatResponse::addToBSON(BSONObjBuilder* builder, bool isProtocolVersionV1) const {
@@ -141,11 +128,6 @@ void ReplSetHeartbeatResponse::addToBSON(BSONObjBuilder* builder, bool isProtoco
             builder->appendDate(kAppliedOpTimeFieldName,
                                 Date_t::fromMillisSinceEpoch(_appliedOpTime.getTimestamp().asLL()));
         }
-    }
-
-    BSONObjBuilder shardVersionsBuilder(builder->subobjStart(kNsShardVersions));
-    for (auto& ns : _nsShardVersions) {
-        shardVersionsBuilder.append(ns.first, ns.second->toBSON());
     }
 }
 
@@ -346,39 +328,6 @@ Status ReplSetHeartbeatResponse::initialize(const BSONObj& doc, long long term) 
                                     << typeName(syncingToElement.type()));
     } else {
         _syncingTo = HostAndPort(syncingToElement.String());
-    }
-
-
-    try {
-        // 新加入的ns的shardversion
-        BSONElement tmpShardVersionElement = doc[kNsShardVersions];
-        if (!tmpShardVersionElement.eoo()) {
-            auto tmpObj = tmpShardVersionElement.Obj();
-            BSONForEach(versionItem, tmpObj) {
-                StringData ns = versionItem.fieldNameStringData();
-                if (ns.empty()) {
-                    continue;
-                }
-
-                auto statusCV = ChunkVersion::parseFromBSONObj(versionItem.Obj());
-                if (!statusCV.isOK()) {
-                    log() << "[MongoStat] can't parse chunk version: ns:" << ns << ":"
-                          << versionItem.Obj() << ",reason:" << statusCV.getStatus().toString();
-                    globalApCounter.gotParseShardVersionError();
-                    continue;
-                }
-                _nsShardVersions[ns.toString()] =
-                    std::make_shared<ChunkVersion>(statusCV.getValue().majorVersion(),
-                                                   statusCV.getValue().minorVersion(),
-                                                   statusCV.getValue().epoch());
-            }
-        } else {
-            globalApCounter.gotParseShardVersionError();
-            LOG(1) << "heartbeat response missing nsShardVersions";
-        }
-    } catch(...) {
-        log() << "heartbeat response parse nsShardVersions has exception, but ignore it";
-        globalApCounter.gotParseShardVersionError();
     }
 
     const BSONElement rsConfigElement = doc[kConfigFieldName];

--- a/src/mongo/db/repl/repl_set_heartbeat_response.h
+++ b/src/mongo/db/repl/repl_set_heartbeat_response.h
@@ -34,7 +34,6 @@
 #include "mongo/db/repl/optime.h"
 #include "mongo/db/repl/repl_set_config.h"
 #include "mongo/util/time_support.h"
-#include "mongo/s/chunk_version.h"
 
 namespace mongo {
 
@@ -134,12 +133,6 @@ public:
         return _durableOpTimeSet;
     }
     OpTime getDurableOpTime() const;
-
-
-    const std::map<std::string, std::shared_ptr<ChunkVersion>>& getNsShardVersions() const {
-        return _nsShardVersions;
-    }
-
 
     /**
      * Sets _mismatch to true.
@@ -255,10 +248,6 @@ public:
         _term = term;
     }
 
-    void setNsShardVersion(const std::map<std::string, std::shared_ptr<ChunkVersion>>& shardVersions) {
-        _nsShardVersions = shardVersions;
-    }
-
 private:
     bool _electionTimeSet = false;
     Timestamp _electionTime;
@@ -296,9 +285,6 @@ private:
     bool _primaryIdSet = false;
     long long _primaryId = -1;
     long long _term = -1;
-
-
-    std::map<std::string, std::shared_ptr<ChunkVersion>> _nsShardVersions;
 };
 
 }  // namespace repl

--- a/src/mongo/db/repl/topology_coordinator_impl.cpp
+++ b/src/mongo/db/repl/topology_coordinator_impl.cpp
@@ -49,10 +49,6 @@
 #include "mongo/db/repl/replication_executor.h"
 #include "mongo/db/repl/rslog.h"
 #include "mongo/db/server_parameters.h"
-#include "mongo/db/service_context.h"
-#include "mongo/db/s/sharding_state.h"
-#include "mongo/db/s/refresh_secondary_routing.h"
-#include "mongo/db/stats/apcounter.h"
 #include "mongo/rpc/metadata/oplog_query_metadata.h"
 #include "mongo/rpc/metadata/repl_set_metadata.h"
 #include "mongo/util/fail_point_service.h"
@@ -830,21 +826,6 @@ Status TopologyCoordinatorImpl::prepareHeartbeatResponseV1(Date_t now,
 
     if (myState.primary()) {
         response->setElectionTime(_electionTime);
-
-        // 只有primary才会有标准的版本信息，并且需要在心跳回复中带上这个信息
-        auto shardingState = ShardingState::get(getGlobalServiceContext());
-        if(shardingState && shardingState->enabled()) {
-            auto tmpVersions = shardingState->getAllShardVersions();
-            response->setNsShardVersion(tmpVersions);
-        } else {
-            if (!shardingState) {
-                log() << "ShardingState is null";
-                globalApCounter.gotShardingStateNull();
-            } else if (!shardingState->enabled()) {
-                log() << "ShardingState not enabled, not setting shard version";
-                globalApCounter.gotShardingStateNotEnable();
-            }
-        }
     }
 
     response->setAppliedOpTime(lastOpApplied);
@@ -1158,55 +1139,7 @@ HeartbeatResponseAction TopologyCoordinatorImpl::_updatePrimaryFromHBDataV1(
     _currentPrimaryIndex = primaryIndex;
     if (_currentPrimaryIndex == -1) {
         return HeartbeatResponseAction::makeNoAction();
-    } else {
-        // 当当前的心跳和primary心跳是一致的时候才会获得版本进行比较
-        if (updatedConfigIndex == _currentPrimaryIndex) {
-            auto shardingState = ShardingState::get(getGlobalServiceContext());
-            if (shardingState && shardingState->enabled()) {
-                auto primaryHbData = _hbdata.at(_currentPrimaryIndex);
-                auto primaryVersions = primaryHbData.getAllShardVersions();
-                auto currentVersions = shardingState->getAllShardVersions();
-
-                /**
-                 * 比较的原则是: 一切以primary为准
-                 * 1. primary有但是secondary没有，那就触发更新
-                 * 2. primary与当前的要新，就放进去,进行刷新;
-                 * 3. secondary版本比较高，那就清空，下次心跳进行更新;
-                 * 4. seondary有但是primary没有的话啊，不触发更新, 这种情况理论上不应该有，有的话对整体的正确性是没问题得;
-                 */
-                for (const auto& pVersion : primaryVersions) {
-                    auto cVersion = currentVersions.find(pVersion.first);
-
-                    if (cVersion == currentVersions.end()) {
-                        refreshSecondaryRoutingJob.putTask(pVersion.first, pVersion.second);
-                        globalApCounter.gotNewCollectionCnt();
-                    } else if (!cVersion->second->isWriteCompatibleWith(*(pVersion.second))) {
-                        if (cVersion->second <= (*(pVersion.second))) {
-                            refreshSecondaryRoutingJob.putTask(pVersion.first, pVersion.second);
-                            globalApCounter.gotCollectionVersionNotCompatible();
-                        } else if (cVersion->second > (*(pVersion.second))) {
-                            refreshSecondaryRoutingJob.putClearTask(pVersion.first);
-                            globalApCounter.gotCollectionVersionNotCompatible();
-                        }
-                    } else {
-                        LOG(1) << "skip update shard version, current version is newer or "
-                                  "compatible with primary";
-                        globalApCounter.gotSkipVersionUpdated();
-                    }
-                }
-
-                for(const auto& cVersion : currentVersions) {
-                    auto pVersion = primaryVersions.find(cVersion.first);
-                    if (pVersion == primaryVersions.end()) {
-                        log() << "[MonogoStat] secondary have version, but primary no version so remove shard version: " << cVersion.first << ":" << cVersion.second->toString();
-                        //refreshSecondaryRoutingJob.putTask(cVersion.first, ChunkVersion::UNSHARDED());
-                        globalApCounter.gotRemoveVersionCnt();
-                    }
-                }
-            }
-        }
-    }
-
+    } 
     // Clear last heartbeat message on ourselves.
     setMyHeartbeatMessage(now, "");
 

--- a/src/mongo/db/repl/topology_coordinator_impl.cpp
+++ b/src/mongo/db/repl/topology_coordinator_impl.cpp
@@ -1170,8 +1170,8 @@ HeartbeatResponseAction TopologyCoordinatorImpl::_updatePrimaryFromHBDataV1(
                 /**
                  * 比较的原则是: 一切以primary为准
                  * 1. primary有但是secondary没有，那就触发更新
-                 * 2. primary与当前的写不兼容的话，就放进去;
-                 * 3. secondary版本比较高，那就不更新
+                 * 2. primary与当前的要新，就放进去,进行刷新;
+                 * 3. secondary版本比较高，那就清空，下次心跳进行更新;
                  * 4. seondary有但是primary没有的话啊，不触发更新, 这种情况理论上不应该有，有的话对整体的正确性是没问题得;
                  */
                 for (const auto& pVersion : primaryVersions) {
@@ -1181,8 +1181,13 @@ HeartbeatResponseAction TopologyCoordinatorImpl::_updatePrimaryFromHBDataV1(
                         refreshSecondaryRoutingJob.putTask(pVersion.first, pVersion.second);
                         globalApCounter.gotNewCollectionCnt();
                     } else if (!cVersion->second->isWriteCompatibleWith(*(pVersion.second))) {
-                        refreshSecondaryRoutingJob.putTask(pVersion.first, pVersion.second);
-                        globalApCounter.gotCollectionVersionNotCompatible();
+                        if (cVersion->second <= (*(pVersion.second))) {
+                            refreshSecondaryRoutingJob.putTask(pVersion.first, pVersion.second);
+                            globalApCounter.gotCollectionVersionNotCompatible();
+                        } else if (cVersion->second > (*(pVersion.second))) {
+                            refreshSecondaryRoutingJob.putClearTask(pVersion.first);
+                            globalApCounter.gotCollectionVersionNotCompatible();
+                        }
                     } else {
                         LOG(1) << "skip update shard version, current version is newer or "
                                   "compatible with primary";

--- a/src/mongo/db/s/SConscript
+++ b/src/mongo/db/s/SConscript
@@ -16,20 +16,20 @@ env.Library(
     ]
 )
 
-env.Library(
-    target='refresh_secondary_routing',
-    source=[
-        'refresh_secondary_routing.cpp',
-    ],
-    LIBDEPS=[
-        '$BUILD_DIR/mongo/base',
-        '$BUILD_DIR/mongo/db/common',
-        '$BUILD_DIR/mongo/s/common',
-        '$BUILD_DIR/mongo/db/service_context',
-        '$BUILD_DIR/mongo/db/stats/apcounter',
-        'sharding',
-    ]
-)
+# env.Library(
+#     target='refresh_secondary_routing',
+#     source=[
+#         'refresh_secondary_routing.cpp',
+#     ],
+#     LIBDEPS=[
+#         '$BUILD_DIR/mongo/base',
+#         '$BUILD_DIR/mongo/db/common',
+#         '$BUILD_DIR/mongo/s/common',
+#         '$BUILD_DIR/mongo/db/service_context',
+#         '$BUILD_DIR/mongo/db/stats/apcounter',
+#         'sharding',
+#     ]
+# )
 
 env.Library(
     target='refresh_metainfo',

--- a/src/mongo/db/s/collection_sharding_state.cpp
+++ b/src/mongo/db/s/collection_sharding_state.cpp
@@ -373,11 +373,14 @@ bool CollectionShardingState::_checkShardVersionOk(OperationContext* txn,
         return true;
     }
 
-    // 让非primary带有版本信息
-    // if (!repl::ReplicationCoordinator::get(txn)->canAcceptWritesForDatabase(_nss.db())) {
-    //     // Right now connections to secondaries aren't versioned at all.
-    //     return true;
-    // }
+
+    //如果开始secondary路由刷新的功能话，就进行版本检查，如果没有开启的话，就不进行版本检查
+    if (!serverGlobalParams.secondaryRouteSwitch) {
+        if (!repl::ReplicationCoordinator::get(txn)->canAcceptWritesForDatabase(_nss.db())) {
+            // Right now connections to secondaries aren't versioned at all.
+            return true;
+        }
+    }
 
     auto& oss = OperationShardingState::get(txn);
 

--- a/src/mongo/db/s/refresh_metainfo.cpp
+++ b/src/mongo/db/s/refresh_metainfo.cpp
@@ -109,7 +109,7 @@ void RefreshMetainfoJob::run() {
             }
         } while (false);
 
-        auto waitSecs = 82800 + rand() % 3600;
+        auto waitSecs = rand() % 3600;
         log() << "i will sleep " << waitSecs << " seconds";
         sleepsecs(waitSecs);
     }

--- a/src/mongo/db/s/refresh_metainfo.cpp
+++ b/src/mongo/db/s/refresh_metainfo.cpp
@@ -109,7 +109,7 @@ void RefreshMetainfoJob::run() {
             }
         } while (false);
 
-        auto waitSecs = rand() % 3600;
+        auto waitSecs = 82800 + rand() % 3600;
         log() << "i will sleep " << waitSecs << " seconds";
         sleepsecs(waitSecs);
     }

--- a/src/mongo/db/s/refresh_secondary_routing.cpp
+++ b/src/mongo/db/s/refresh_secondary_routing.cpp
@@ -12,9 +12,11 @@
 #include "mongo/util/scopeguard.h"
 #include "mongo/util/timer.h"
 #include "mongo/util/exit.h"
+#include <set>
 
 namespace mongo {
 using std::map;
+using std::set;
 using std::shared_ptr;
 using std::string;
 using stdx::mutex;
@@ -25,6 +27,11 @@ RefreshSecondaryRoutingJob refreshSecondaryRoutingJob;
 
 std::string RefreshSecondaryRoutingJob::name() const {
     return kRefreshSecondaryRoutingJobName;
+}
+
+void RefreshSecondaryRoutingJob::putClearTask(const string& ns) {
+    stdx::lock_guard<stdx::mutex> lk(_mutex);
+    _clearPool.insert(ns);
 }
 
 void RefreshSecondaryRoutingJob::putTask(const string& ns,
@@ -85,27 +92,30 @@ void RefreshSecondaryRoutingJob::run() {
             if (replCoord && replCoord->isReplEnabled() &&
                 replCoord->getMemberState().secondary()) {
                 map<string, shared_ptr<ChunkVersion>> copyMap;
+                set<string> clearSet;
                 {
                     Timer t;
                     ON_BLOCK_EXIT([&t] {
                         auto cs = t.millis();
                         if (cs > 10) {
-                            log() << "[MongoStat]RefreshSecondaryRoutingJob::run() copyMap took "
+                            log() << "[MongoStat]RefreshSecondaryRoutingJob::run() copyMap and copySet took "
                                   << cs << "ms";
                         }
                     });
 
                     stdx::lock_guard<mutex> lk(_mutex);
                     copyMap = _taskPool;
+                    clearSet = _clearPool;
                     _taskPool.clear();
+                    _clearPool.clear();
                 }
 
                 {
                     Timer t;
-                    ON_BLOCK_EXIT([&copyMap, &t] {
-                        if (!copyMap.empty()) {
-                            log() << "[MongoStat]RefreshSecondaryRoutingJob::run() task size:"
-                                  << copyMap.size() << ",refresh routing took " << t.millis()
+                    ON_BLOCK_EXIT([&copyMap, &t, &clearSet] {
+                        if (!copyMap.empty() || !clearSet.empty()) {
+                            log() << "[MongoStat]RefreshSecondaryRoutingJob::run() update task size:"
+                                  << copyMap.size() << " and clear task:"<< clearSet.size() << ",refresh routing took " << t.millis()
                                   << "ms";
                         }
                     });
@@ -122,6 +132,11 @@ void RefreshSecondaryRoutingJob::run() {
                               << " version: " << version->toString();
                         shardingState->onStaleShardVersion(&txn, NamespaceString(ns), *version);
                         globalApCounter.gotOnStaleShardVersion();
+                    }
+
+                    for (const auto& ns : clearSet) {
+                        log() << "[MongoStat]RefreshSecondaryRoutingJob::run() clear ns: " << ns;
+                        shardingState->markCollectionNotShardedAtStepdown(ns);
                     }
                 }
                 sleepmillis(500);

--- a/src/mongo/db/s/refresh_secondary_routing.h
+++ b/src/mongo/db/s/refresh_secondary_routing.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <map>
+#include <set>
 #include <string>
 
 #include "mongo/stdx/mutex.h"

--- a/src/mongo/db/s/refresh_secondary_routing.h
+++ b/src/mongo/db/s/refresh_secondary_routing.h
@@ -19,8 +19,10 @@ public:
     std::string name() const final;
     void run() final;
     void putTask(const std::string& ns, const std::shared_ptr<ChunkVersion>& version);
+    void putClearTask(const std::string& ns);
 private:
     std::map<std::string, std::shared_ptr<ChunkVersion>> _taskPool;
+    std::set<std::string> _clearPool;
     // 用来保护 map
     stdx::mutex _mutex;
 };

--- a/src/mongo/db/s/sharding_state.cpp
+++ b/src/mongo/db/s/sharding_state.cpp
@@ -267,6 +267,21 @@ void ShardingState::markCollectionsNotShardedAtStepdown() {
     }
 }
 
+void ShardingState::markCollectionNotShardedAtStepdown(const std::string& ns) {
+    if(ns.empty()) {
+        return;
+    }
+
+    stdx::lock_guard<stdx::mutex> lk(_mutex);
+    auto item = _collections.find(ns);
+    if (item != _collections.end()) {
+        if (item->second) {
+            item->second->markNotShardedAtStepdown();
+            log() << "[MongoStat] Marked collection " << ns << " as not sharded at stepdown";
+        }
+    }
+}
+
 void ShardingState::setGlobalInitMethodForTest(GlobalInitFunc func) {
     _globalInit = func;
 }

--- a/src/mongo/db/s/sharding_state.cpp
+++ b/src/mongo/db/s/sharding_state.cpp
@@ -50,7 +50,7 @@
 #include "mongo/db/s/sharded_connection_info.h"
 #include "mongo/db/s/sharding_initialization_mongod.h"
 #include "mongo/db/s/sharding_statistics.h"
-#include "mongo/db/s/refresh_metainfo.h"
+// #include "mongo/db/s/refresh_metainfo.h"
 #include "mongo/db/s/type_shard_identity.h"
 #include "mongo/executor/network_interface_factory.h"
 #include "mongo/executor/network_interface_thread_pool.h"
@@ -67,8 +67,6 @@
 #include "mongo/s/sharding_initialization.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
-#include "mongo/util/timer.h"
-#include "mongo/util/scopeguard.h"
 
 #include <chrono>
 #include <ctime>
@@ -201,49 +199,6 @@ Status ShardingState::updateConfigServerOpTimeFromMetadata(OperationContext* txn
     return Status::OK();
 }
 
-std::map<std::string, std::shared_ptr<ChunkVersion>> ShardingState::getAllShardVersions() {
-    static std::shared_ptr<ChunkVersion> kUninitializedChunkVersion(
-        new ChunkVersion(0, 0, OID()));
-
-    Timer timer;
-    ON_BLOCK_EXIT([&timer] {  
-        auto cs = timer.millis();
-        if (cs > 10) {
-            log() << "[ShardingState::getAllShardVersions] getAllShardVersions() took " << cs << "ms";
-        }
-    });
-
-    std::map<std::string, std::shared_ptr<ChunkVersion>> allShardVersions;
-    std::shared_ptr<std::set<std::string>> csSharedCollections = refreshMetaInfoJob.getSharedCollections();
-
-    {
-        stdx::lock_guard<stdx::mutex> lk(_mutex);
-        for (const auto& coll : _collections) {
-            if (coll.second == nullptr) {
-                continue;
-            }
-
-            std::shared_ptr<ChunkVersion> newTmp = kUninitializedChunkVersion;
-            if (coll.second->getMetadata()) {
-                auto tmpChunkVersion = coll.second->getMetadata()->getShardVersion();
-                newTmp = std::make_shared<ChunkVersion>(tmpChunkVersion.majorVersion(),
-                                                        tmpChunkVersion.minorVersion(),
-                                                        tmpChunkVersion.epoch());
-                allShardVersions[coll.first] = newTmp;
-            } else {
-                if (csSharedCollections && csSharedCollections->find(coll.first) !=
-                                               csSharedCollections->end()) {
-                    // This collection is shared with the config server, so we can't
-                    // get the shard version from the metadata.
-                    allShardVersions[coll.first] = newTmp;
-                }
-            }
-        }
-    }
-
-    return allShardVersions;
-}
-
 CollectionShardingState* ShardingState::getNS(const std::string& ns, OperationContext* txn) {
     stdx::lock_guard<stdx::mutex> lk(_mutex);
     CollectionShardingStateMap::iterator it = _collections.find(ns);
@@ -264,21 +219,6 @@ void ShardingState::markCollectionsNotShardedAtStepdown() {
     for (auto& coll : _collections) {
         auto& css = coll.second;
         css->markNotShardedAtStepdown();
-    }
-}
-
-void ShardingState::markCollectionNotShardedAtStepdown(const std::string& ns) {
-    if(ns.empty()) {
-        return;
-    }
-
-    stdx::lock_guard<stdx::mutex> lk(_mutex);
-    auto item = _collections.find(ns);
-    if (item != _collections.end()) {
-        if (item->second) {
-            item->second->markNotShardedAtStepdown();
-            log() << "[MongoStat] Marked collection " << ns << " as not sharded at stepdown";
-        }
     }
 }
 

--- a/src/mongo/db/s/sharding_state.h
+++ b/src/mongo/db/s/sharding_state.h
@@ -136,18 +136,10 @@ public:
     CollectionShardingState* getNS(const std::string& ns, OperationContext* txn);
 
     /**
-     * Returns the shard version for all namespace.
-     */
-    std::map<std::string, std::shared_ptr<ChunkVersion>> getAllShardVersions();
-
-    /**
      * Iterates through all known sharded collections and marks them (in memory only) as not sharded
      * so that no filtering will be happening for slaveOk queries.
      */
     void markCollectionsNotShardedAtStepdown();
-
-    //清空某一个 ns 的元信息
-    void markCollectionNotShardedAtStepdown(const std::string& ns);
 
     /**
      * Refreshes the local metadata based on whether the expected version is higher than what we

--- a/src/mongo/db/s/sharding_state.h
+++ b/src/mongo/db/s/sharding_state.h
@@ -146,6 +146,9 @@ public:
      */
     void markCollectionsNotShardedAtStepdown();
 
+    //清空某一个 ns 的元信息
+    void markCollectionNotShardedAtStepdown(const std::string& ns);
+
     /**
      * Refreshes the local metadata based on whether the expected version is higher than what we
      * have cached.

--- a/src/mongo/db/server_options.h
+++ b/src/mongo/db/server_options.h
@@ -90,6 +90,8 @@ struct ServerGlobalParams {
     // 新增参数用来设定
     int listenBacklog = 1024;  // Maximum number of connections in the listen queue.
 
+    std::atomic<bool> secondaryRouteSwitch{true};  // --secondaryRouteSwitch
+
     int unixSocketPermissions = DEFAULT_UNIX_PERMS;  // permissions for the UNIX domain socket
 
     std::string keyFile;  // Path to keyfile, or empty if none.

--- a/src/mongo/db/server_options_helpers.cpp
+++ b/src/mongo/db/server_options_helpers.cpp
@@ -195,6 +195,8 @@ Status addGeneralServerOptions(moe::OptionSection* options) {
     // add option to specify the max number of accept queue
     options->addOptionChaining("listen.backlog", "listenBacklog", moe::Int, "listen backlog, default 1024");
 
+    options->addOptionChaining("secondary.route", "secondaryRouteSwitch", moe::Switch, "secondary route switch, default true");
+
     options->addOptionChaining(
         "net.ipv6", "ipv6", moe::Switch, "enable IPv6 support (disabled by default)");
 
@@ -841,6 +843,10 @@ Status storeServerOptions(const moe::Environment& params) {
 
     if (params.count("listen.backlog")) {
         serverGlobalParams.listenBacklog = params["listen.backlog"].as<int>();
+    }
+
+    if (params.count("secondary.route")) {
+        serverGlobalParams.secondaryRouteSwitch = params["secondary.route"].as<bool>();
     }
 
     if (params.count("net.ipv6") && params["net.ipv6"].as<bool>() == true) {

--- a/src/mongo/db/stats/apcounter.cpp
+++ b/src/mongo/db/stats/apcounter.cpp
@@ -78,47 +78,6 @@ void ApCounter::gotShardHostLimit() {
     _shardHostLimit.fetchAndAdd(1);
 }
 
-void ApCounter::gotShardingStateNull() {
-    RARELY _checkWrap();
-    _shardingStateNull.fetchAndAdd(1);
-}
-
-void ApCounter::gotShardingStateNotEnable() {
-    RARELY _checkWrap();
-    _shardingStateNotEnable.fetchAndAdd(1);
-}
-void ApCounter::gotNewCollectionCnt() {
-    RARELY _checkWrap();
-    _newCollectionCnt.fetchAndAdd(1);
-}
-
-void ApCounter::gotRemoveVersionCnt() {
-    RARELY _checkWrap();
-    _removeVersionCnt.fetchAndAdd(1);
-}
-void ApCounter::gotCollectionVersionNotCompatible() {
-    RARELY _checkWrap();
-    _collectionVersionNotCompatible.fetchAndAdd(1);
-}
-void ApCounter::gotSkipVersionUpdated() {
-    RARELY _checkWrap();
-    _skipVersionUpdated.fetchAndAdd(1);
-}
-void ApCounter::gotEpochNotEqual() {
-    RARELY _checkWrap();
-    _epochNotEqual.fetchAndAdd(1);
-}
-
-void ApCounter::gotOnStaleShardVersion() {
-    RARELY _checkWrap();
-    _onStaleShardVersion.fetchAndAdd(1);
-}
-
-void ApCounter::gotParseShardVersionError() {
-    RARELY _checkWrap();
-    _parseShardVersionError.fetchAndAdd(1);
-}
-
 void ApCounter::_checkWrap() {
     const unsigned MAX = 1 << 30;
 
@@ -130,12 +89,6 @@ void ApCounter::_checkWrap() {
         _legacyConnectionLimit.loadRelaxed() > MAX || _asioWaitReqQueueLimit.loadRelaxed() > MAX ||
         _shardHostLimit.loadRelaxed() > MAX || _readUnSlowLog.loadRelaxed() > MAX;
 
-
-        wrap = wrap ? true : (_shardingStateNull.loadRelaxed() > MAX || _shardingStateNotEnable.loadRelaxed() > MAX ||
-            _newCollectionCnt.loadRelaxed() > MAX ||
-            _collectionVersionNotCompatible.loadRelaxed() > MAX ||
-            _skipVersionUpdated.loadRelaxed() > MAX || _epochNotEqual.loadRelaxed() > MAX ||
-            _onStaleShardVersion.loadRelaxed() > MAX || _parseShardVersionError.loadRelaxed() > MAX || _removeVersionCnt.loadRelaxed() > MAX);
 
     if (wrap) {
         _readAp.store(0);
@@ -155,16 +108,6 @@ void ApCounter::_checkWrap() {
         _legacyConnectionLimit.store(0);
         _asioWaitReqQueueLimit.store(0);
         _shardHostLimit.store(0);
-
-        _shardingStateNull.store(0);
-        _shardingStateNotEnable.store(0);
-        _newCollectionCnt.store(0);
-        _removeVersionCnt.store(0);
-        _collectionVersionNotCompatible.store(0);
-        _skipVersionUpdated.store(0);
-        _epochNotEqual.store(0);
-        _onStaleShardVersion.store(0);
-        _parseShardVersionError.store(0);
     }
 }
 
@@ -186,17 +129,6 @@ BSONObj ApCounter::getObj() const {
     b.append("limitForLegacy", _legacyConnectionLimit.loadRelaxed());
     b.append("limitForAsioReqQ", _asioWaitReqQueueLimit.loadRelaxed());
     b.append("limitForRefresh", _shardHostLimit.loadRelaxed());
-
-    b.append("sharding_state_null", _shardingStateNull.loadRelaxed());
-    b.append("sharding_state_not_enable", _shardingStateNotEnable.loadRelaxed());
-    b.append("new_collection_cnt", _newCollectionCnt.loadRelaxed());
-    b.append("primary_null_version_cnt", _removeVersionCnt.loadRelaxed());
-    b.append("collection_version_not_compatible", _collectionVersionNotCompatible.loadRelaxed());
-    b.append("skip_version_updated", _skipVersionUpdated.loadRelaxed());
-    b.append("epoch_not_equal", _epochNotEqual.loadRelaxed());
-    b.append("on_stale_shard_version", _onStaleShardVersion.loadRelaxed());
-    b.append("parse_shard_version_error", _parseShardVersionError.loadRelaxed());
-
     return b.obj();
 }
 

--- a/src/mongo/db/stats/apcounter.h
+++ b/src/mongo/db/stats/apcounter.h
@@ -27,18 +27,6 @@ class ApCounter {
     void gotAsioWaitReqQueueLimit();
     void gotShardHostLimit();
 
-    // heartbeat monitor
-    void gotShardingStateNull();
-    void gotShardingStateNotEnable();
-    void gotNewCollectionCnt();
-    void gotRemoveVersionCnt();
-    void gotCollectionVersionNotCompatible();
-    void gotSkipVersionUpdated();
-    void gotEpochNotEqual();
-    void gotOnStaleShardVersion();
-    void gotParseShardVersionError();
-    
-
 
     BSONObj getObj() const;
 
@@ -94,43 +82,6 @@ class ApCounter {
     const AtomicUInt32* getShardHostLimit() const {
         return &_shardHostLimit;
     }
-
-    const AtomicUInt32* getShardingStateNull() const {
-        return &_shardingStateNull;
-    }
-
-    const AtomicUInt32* getShardingStateNotEnable() const {
-        return &_shardingStateNotEnable;
-    }
-
-    const AtomicUInt32* getRemoveVersionCnt() const {
-        return &_removeVersionCnt;
-    }
-
-    const AtomicUInt32* getNewCollectionCnt() const {
-        return &_newCollectionCnt;
-    }
-
-    const AtomicUInt32* getCollectionVersionNotCompatible() const {
-        return &_collectionVersionNotCompatible;
-    }
-
-    const AtomicUInt32* getSkipVersionUpdated() const {
-        return &_skipVersionUpdated;
-    }
-
-    const AtomicUInt32* getEpochNotEqual() const {
-        return &_epochNotEqual;
-    }
-
-    const AtomicUInt32* getOnStaleShardVersion() const {
-        return &_onStaleShardVersion;
-    }
-
-    const AtomicUInt32* getParseShardVersionError() const {
-        return &_parseShardVersionError;
-    }
-
     private:
     
         void _checkWrap();
@@ -155,21 +106,6 @@ class ApCounter {
         AtomicUInt32 _legacyConnectionLimit;
         AtomicUInt32 _asioWaitReqQueueLimit;
         AtomicUInt32 _shardHostLimit;
-
-
-        // heartbeat monitor
-        AtomicUInt32 _shardingStateNull;
-        AtomicUInt32 _shardingStateNotEnable;
-
-        AtomicUInt32 _newCollectionCnt;
-        AtomicUInt32 _collectionVersionNotCompatible;
-        AtomicUInt32 _skipVersionUpdated;
-        AtomicUInt32 _removeVersionCnt;
-
-        AtomicUInt32 _epochNotEqual;
-        AtomicUInt32 _onStaleShardVersion;
-
-        AtomicUInt32 _parseShardVersionError;
 };
 
 extern ApCounter globalApCounter;

--- a/src/mongo/s/chunk_version.cpp
+++ b/src/mongo/s/chunk_version.cpp
@@ -134,35 +134,4 @@ BSONObj ChunkVersion::toBSON() const {
     b.append(_epoch);
     return b.arr();
 }
-
-StatusWith<ChunkVersion> ChunkVersion::parseFromBSONObj(const BSONObj& obj) {
-    BSONObjIterator it(obj);
-    if (!it.more())
-        return {ErrorCodes::BadValue, "Unexpected empty version"};
-
-    ChunkVersion version;
-    // Expect the timestamp
-    {
-        BSONElement tsPart = it.next();
-        if (tsPart.type() != bsonTimestamp)
-            return {ErrorCodes::TypeMismatch,
-                    str::stream() << "Invalid type " << tsPart.type()
-                                  << " for version timestamp part."};
-
-        version._combined = tsPart.timestamp().asULL();
-    }
-
-    // Expect the epoch OID
-    {
-        BSONElement epochPart = it.next();
-        if (epochPart.type() != jstOID)
-            return {ErrorCodes::TypeMismatch,
-                    str::stream() << "Invalid type " << epochPart.type()
-                                  << " for version epoch part."};
-
-        version._epoch = epochPart.OID();
-    }
-    return version;
-}
-
 }  // namespace mongo

--- a/src/mongo/s/chunk_version.h
+++ b/src/mongo/s/chunk_version.h
@@ -98,10 +98,6 @@ public:
      */
     static StatusWith<ChunkVersion> parseFromBSONForChunk(const BSONObj& obj);
 
-    // 新加的解析 chunkversion;
-    // 原因主要是因为 chunkVersion 自带的 toBson 方法返回的 Obj 没有函数能直接进行解析; 上面几个都是有着自己特定结构    
-    static StatusWith<ChunkVersion> parseFromBSONObj(const BSONObj& obj);
-
     /**
      * Indicates a dropped collection. All components are zeroes (OID is zero time, zero
      * machineId/inc).


### PR DESCRIPTION
## 重大改动

之前灰度上线的[KODO-13447 secondary支持路由刷新的功能](https://github.com/qiniu/percona-server-mongodb/pull/28)、[KODO-14435 解决mongo dumpchunks 命令导致crash](https://github.com/qiniu/percona-server-mongodb/pull/30)和[KODO-14454 mongod/mongos 启动主动加载路由信息](https://github.com/qiniu/percona-server-mongodb/pull/31)这几个pr的整体策略进行了修改，所以这个版本是删减了功能；

与[wait for secondary ms to slowlog](https://github.com/qiniu/percona-server-mongodb/pull/29)这个pr进行比较，增加了以下几个功能:

* 增加了可以通过配置来进行指定listenBacklog的参数，默认1024
* 为mongos，mongod增加了启动端口之前，优先进行路由刷新
* secondary可以通过mongos来触发路由刷新，让secondary带上了版本
* mongos mongod编译的二进制带上专门版本信息
* mongod 支持dumpchunks的命令