### PR TITLE
1.oplog添加附加信息 2.二级路由shard迁移空的bug修复，代码集中在chunk_manager_inlock.h chunk_…

### DIFF
--- a/src/mongo/db/bson/SConscript
+++ b/src/mongo/db/bson/SConscript
@@ -6,6 +6,7 @@ env.Library(
     target="dotted_path_support",
     source=[
         "dotted_path_support.cpp",
+        "trace_additional_from_query.cpp",
     ],
     LIBDEPS=[
         "$BUILD_DIR/mongo/base",

--- a/src/mongo/db/bson/trace_additional_from_query.cpp
+++ b/src/mongo/db/bson/trace_additional_from_query.cpp
@@ -3,11 +3,12 @@
 #include "mongo/db/bson/trace_additional_from_query.h"
 namespace mongo {
 namespace trace_query {
+const std::string KODOMSG = "@kodoMsg@";
 bool traceAdditionalInfoFromQuery(BSONObj& query, BSONObj& additional){
     bool ret = false;
-    if (query.hasElement("@kodoMsg@")) {
-        additional = query.getObjectField("@kodoMsg@");
-        query = query.removeField("@kodoMsg@");
+    if (query.hasElement(KODOMSG)) {
+        additional = query.getObjectField(KODOMSG);
+        query = query.removeField(KODOMSG);
         ret = true;
     }
     return ret;

--- a/src/mongo/db/bson/trace_additional_from_query.cpp
+++ b/src/mongo/db/bson/trace_additional_from_query.cpp
@@ -1,0 +1,24 @@
+/*
+ * @Author: your name
+ * @Date: 2022-03-11 16:18:11
+ * @LastEditTime: 2022-03-11 17:00:50
+ * @LastEditors: Please set LastEditors
+ * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ * @FilePath: /percona-server-mongodb/src/mongo/db/bson/trace_additional_from_query.cpp
+ */
+#include "mongo/bson/bsonmisc.h"
+#include "mongo/bson/bsonobj.h"
+#include "mongo/db/bson/trace_additional_from_query.h"
+namespace mongo {
+namespace trace_query {
+bool traceAdditionalInfoFromQuery(BSONObj& query, BSONObj& additional){
+    bool ret = false;
+    if (query.hasElement("@kodoMsg@")) {
+        additional = query.getObjectField("@kodoMsg@");
+        query = query.removeField("@kodoMsg@");
+        ret = true;
+    }
+    return ret;
+}
+}
+}

--- a/src/mongo/db/bson/trace_additional_from_query.cpp
+++ b/src/mongo/db/bson/trace_additional_from_query.cpp
@@ -1,11 +1,3 @@
-/*
- * @Author: your name
- * @Date: 2022-03-11 16:18:11
- * @LastEditTime: 2022-03-11 17:00:50
- * @LastEditors: Please set LastEditors
- * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
- * @FilePath: /percona-server-mongodb/src/mongo/db/bson/trace_additional_from_query.cpp
- */
 #include "mongo/bson/bsonmisc.h"
 #include "mongo/bson/bsonobj.h"
 #include "mongo/db/bson/trace_additional_from_query.h"

--- a/src/mongo/db/bson/trace_additional_from_query.h
+++ b/src/mongo/db/bson/trace_additional_from_query.h
@@ -1,0 +1,21 @@
+/*
+ * @Author: your name
+ * @Date: 2022-03-11 16:17:45
+ * @LastEditTime: 2022-03-11 16:27:08
+ * @LastEditors: Please set LastEditors
+ * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ * @FilePath: /percona-server-mongodb/src/mongo/db/bson/trace_additional_from_query.h
+ */
+#pragma once
+
+#include <cstddef>
+#include <set>
+
+#include "mongo/bson/bsonelement_comparator_interface.h"
+#include "mongo/bson/bsonobj.h"
+
+namespace mongo {
+namespace trace_query {
+    bool traceAdditionalInfoFromQuery(BSONObj& query, BSONObj& additional);
+}
+}

--- a/src/mongo/db/bson/trace_additional_from_query.h
+++ b/src/mongo/db/bson/trace_additional_from_query.h
@@ -1,9 +1,9 @@
 /*
  * @Author: your name
  * @Date: 2022-03-11 16:17:45
- * @LastEditTime: 2022-03-11 16:27:08
+ * @LastEditTime: 2022-03-28 16:15:49
  * @LastEditors: Please set LastEditors
- * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ * @Description: 从query的bson中提取为kodo定制的附加信息bson
  * @FilePath: /percona-server-mongodb/src/mongo/db/bson/trace_additional_from_query.h
  */
 #pragma once

--- a/src/mongo/db/catalog/capped_utils.cpp
+++ b/src/mongo/db/catalog/capped_utils.cpp
@@ -215,7 +215,7 @@ Status cloneCollectionAsCapped(OperationContext* txn,
             WriteUnitOfWork wunit(txn);
             OpDebug* const nullOpDebug = nullptr;
             toCollection->insertDocument(
-                txn, objToClone.value(), nullOpDebug, true, txn->writesAreReplicated());
+                txn, objToClone.value(), nullOpDebug, BSONObj(), true, txn->writesAreReplicated());
             wunit.commit();
 
             // Go to the next document

--- a/src/mongo/db/catalog/collection.cpp
+++ b/src/mongo/db/catalog/collection.cpp
@@ -375,6 +375,7 @@ Status Collection::insertDocuments(OperationContext* txn,
                                    const vector<BSONObj>::const_iterator begin,
                                    const vector<BSONObj>::const_iterator end,
                                    OpDebug* opDebug,
+                                   const std::vector<BSONObj>& vecAdditionalInfo,
                                    bool enforceQuota,
                                    bool fromMigrate) {
 
@@ -419,7 +420,7 @@ Status Collection::insertDocuments(OperationContext* txn,
         return status;
     invariant(sid == txn->recoveryUnit()->getSnapshotId());
 
-    getGlobalServiceContext()->getOpObserver()->onInserts(txn, ns(), begin, end, fromMigrate);
+    getGlobalServiceContext()->getOpObserver()->onInserts(txn, ns(), begin, end, vecAdditionalInfo, fromMigrate);
 
     txn->recoveryUnit()->onCommit([this]() { notifyCappedWaitersIfNeeded(); });
 
@@ -429,11 +430,14 @@ Status Collection::insertDocuments(OperationContext* txn,
 Status Collection::insertDocument(OperationContext* txn,
                                   const BSONObj& docToInsert,
                                   OpDebug* opDebug,
+                                  const BSONObj& additionalInfo,
                                   bool enforceQuota,
                                   bool fromMigrate) {
     vector<BSONObj> docs;
     docs.push_back(docToInsert);
-    return insertDocuments(txn, docs.begin(), docs.end(), opDebug, enforceQuota, fromMigrate);
+    vector<BSONObj> vecAdditionalInfo;
+    vecAdditionalInfo.push_back(additionalInfo);
+    return insertDocuments(txn, docs.begin(), docs.end(), opDebug, vecAdditionalInfo, enforceQuota, fromMigrate);
 }
 
 Status Collection::insertDocument(OperationContext* txn,
@@ -464,6 +468,8 @@ Status Collection::insertDocument(OperationContext* txn,
 
     vector<BSONObj> docs;
     docs.push_back(doc);
+    vector<BSONObj> vecAdditionalInfo;
+    vecAdditionalInfo.push_back(BSONObj());
 
     getGlobalServiceContext()->getOpObserver()->aboutToInserts(
         txn, ns(), docs.begin(), docs.end(), false);
@@ -485,7 +491,7 @@ Status Collection::insertDocument(OperationContext* txn,
     }
 
     getGlobalServiceContext()->getOpObserver()->onInserts(
-        txn, ns(), docs.begin(), docs.end(), false);
+        txn, ns(), docs.begin(), docs.end(), vecAdditionalInfo, false);
 
     txn->recoveryUnit()->onCommit([this]() { notifyCappedWaitersIfNeeded(); });
 
@@ -520,6 +526,7 @@ Status Collection::_insertDocuments(OperationContext* txn,
     records.reserve(count);
     for (auto it = begin; it != end; it++) {
         Record record = {RecordId(), RecordData(it->objdata(), it->objsize())};
+        //log()<<"lixin record="<<record.data.toBson().toString();
         records.push_back(record);
     }
     Status status = _recordStore->insertRecords(txn, &records, _enforceQuota(enforceQuota));
@@ -535,6 +542,7 @@ Status Collection::_insertDocuments(OperationContext* txn,
         invariant(loc < RecordId::max());
 
         BsonRecord bsonRecord = {loc, &(*it)};
+        //log()<<"lixin bsonRecord="<<bsonRecord.docPtr->toString();
         bsonRecords.push_back(bsonRecord);
     }
 
@@ -575,7 +583,7 @@ Status Collection::aboutToDeleteCapped(OperationContext* txn,
 }
 
 void Collection::deleteDocument(
-    OperationContext* txn, const RecordId& loc, OpDebug* opDebug, bool fromMigrate, bool noWarn) {
+    OperationContext* txn, const RecordId& loc, OpDebug* opDebug, const BSONObj& additionalInfo, bool fromMigrate, bool noWarn) {
     if (isCapped()) {
         log() << "failing remove on a capped ns " << _ns;
         uasserted(10089, "cannot remove from a capped collection");
@@ -599,7 +607,7 @@ void Collection::deleteDocument(
     _recordStore->deleteRecord(txn, loc);
 
     getGlobalServiceContext()->getOpObserver()->onDelete(
-        txn, ns(), std::move(deleteState), fromMigrate);
+        txn, ns(), std::move(deleteState), fromMigrate, additionalInfo);
 }
 
 Counter64 moveCounter;

--- a/src/mongo/db/catalog/collection.h
+++ b/src/mongo/db/catalog/collection.h
@@ -260,6 +260,7 @@ public:
     void deleteDocument(OperationContext* txn,
                         const RecordId& loc,
                         OpDebug* opDebug,
+                        const BSONObj& additionalInfo,
                         bool fromMigrate = false,
                         bool noWarn = false);
 
@@ -274,6 +275,7 @@ public:
                            std::vector<BSONObj>::const_iterator begin,
                            std::vector<BSONObj>::const_iterator end,
                            OpDebug* opDebug,
+                           const std::vector<BSONObj>& vecAdditionalInfo,
                            bool enforceQuota,
                            bool fromMigrate = false);
 
@@ -287,6 +289,7 @@ public:
     Status insertDocument(OperationContext* txn,
                           const BSONObj& doc,
                           OpDebug* opDebug,
+                          const BSONObj& additionalInfo,
                           bool enforceQuota,
                           bool fromMigrate = false);
 

--- a/src/mongo/db/cloner.cpp
+++ b/src/mongo/db/cloner.cpp
@@ -266,7 +266,7 @@ struct Cloner::Fun {
 
                 BSONObj doc = tmp;
                 OpDebug* const nullOpDebug = nullptr;
-                Status status = collection->insertDocument(txn, doc, nullOpDebug, true);
+                Status status = collection->insertDocument(txn, doc, nullOpDebug, BSONObj(), true);
                 if (!status.isOK() && status.code() != ErrorCodes::DuplicateKey) {
                     error() << "error: exception cloning object in " << from_collection << ' '
                             << redact(status) << " obj:" << redact(doc);

--- a/src/mongo/db/commands/find_and_modify.cpp
+++ b/src/mongo/db/commands/find_and_modify.cpp
@@ -151,6 +151,7 @@ void makeUpdateRequest(const FindAndModifyRequest& args,
     requestOut->setYieldPolicy(PlanExecutor::YIELD_AUTO);
     requestOut->setExplain(explain);
     requestOut->setLifecycle(updateLifecycle);
+    requestOut->setAdditionalInfo(args.getAdditionalInfo());
 }
 
 void makeDeleteRequest(const FindAndModifyRequest& args, bool explain, DeleteRequest* requestOut) {
@@ -162,6 +163,7 @@ void makeDeleteRequest(const FindAndModifyRequest& args, bool explain, DeleteReq
     requestOut->setYieldPolicy(PlanExecutor::YIELD_AUTO);
     requestOut->setReturnDeleted(true);  // Always return the old value.
     requestOut->setExplain(explain);
+    requestOut->setAdditionalInfo(args.getAdditionalInfo());
 }
 
 void appendCommandResponse(PlanExecutor* exec,

--- a/src/mongo/db/commands/mr.cpp
+++ b/src/mongo/db/commands/mr.cpp
@@ -743,7 +743,7 @@ void State::insert(const string& ns, const BSONObj& o) {
 
         // TODO: Consider whether to pass OpDebug for stats tracking under SERVER-23261.
         OpDebug* const nullOpDebug = nullptr;
-        uassertStatusOK(coll->insertDocument(_txn, bo, nullOpDebug, true));
+        uassertStatusOK(coll->insertDocument(_txn, bo, nullOpDebug, BSONObj(), true));
         wuow.commit();
     }
     MONGO_WRITE_CONFLICT_RETRY_LOOP_END(_txn, "M/R insert", ns);
@@ -776,7 +776,7 @@ void State::_insertToInc(BSONObj& o) {
 
         // TODO: Consider whether to pass OpDebug for stats tracking under SERVER-23261.
         OpDebug* const nullOpDebug = nullptr;
-        uassertStatusOK(coll->insertDocument(_txn, o, nullOpDebug, true, false));
+        uassertStatusOK(coll->insertDocument(_txn, o, nullOpDebug, BSONObj(), true, false));
         wuow.commit();
     }
     MONGO_WRITE_CONFLICT_RETRY_LOOP_END(_txn, "M/R insertToInc", _config.incLong);

--- a/src/mongo/db/commands/test_commands.cpp
+++ b/src/mongo/db/commands/test_commands.cpp
@@ -103,7 +103,7 @@ public:
             }
         }
         OpDebug* const nullOpDebug = nullptr;
-        Status status = collection->insertDocument(txn, obj, nullOpDebug, false);
+        Status status = collection->insertDocument(txn, obj, nullOpDebug, BSONObj(), false);
         if (status.isOK()) {
             wunit.commit();
         }

--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -225,7 +225,7 @@ void logStartup(OperationContext* txn) {
     invariant(collection);
 
     OpDebug* const nullOpDebug = nullptr;
-    uassertStatusOK(collection->insertDocument(txn, o, nullOpDebug, false));
+    uassertStatusOK(collection->insertDocument(txn, o, nullOpDebug, BSONObj(), false));
     wunit.commit();
 }
 

--- a/src/mongo/db/dbhelpers.cpp
+++ b/src/mongo/db/dbhelpers.cpp
@@ -448,7 +448,7 @@ long long Helpers::removeRange(OperationContext* txn,
                         callback->goingToDelete(obj);
 
                     OpDebug* const nullOpDebug = nullptr;
-                    collection->deleteDocument(txn, rloc, nullOpDebug, fromMigrate);
+                    collection->deleteDocument(txn, rloc, nullOpDebug, BSONObj(), fromMigrate);
                     wuow.commit();
                 }
                 MONGO_WRITE_CONFLICT_RETRY_LOOP_END(txn, "delete range", ns);

--- a/src/mongo/db/exec/delete.cpp
+++ b/src/mongo/db/exec/delete.cpp
@@ -215,7 +215,7 @@ PlanStage::StageState DeleteStage::doWork(WorkingSetID* out) {
     if (!_params.isExplain) {
         try {
             WriteUnitOfWork wunit(getOpCtx());
-            _collection->deleteDocument(getOpCtx(), recordId, _params.opDebug, _params.fromMigrate);
+            _collection->deleteDocument(getOpCtx(), recordId, _params.opDebug, _params.additional, _params.fromMigrate);
             wunit.commit();
         } catch (const WriteConflictException& wce) {
             memberFreer.Dismiss();  // Keep this member around so we can retry deleting it.

--- a/src/mongo/db/exec/delete.cpp
+++ b/src/mongo/db/exec/delete.cpp
@@ -171,6 +171,7 @@ PlanStage::StageState DeleteStage::doWork(WorkingSetID* out) {
     // Deletes can't have projections. This means that covering analysis will always add
     // a fetch. We should always get fetched data, and never just key data.
     invariant(member->hasObj());
+    auto delete_obj = member->obj.value();
 
     // Ensure the document still exists and matches the predicate.
     bool docStillMatches;

--- a/src/mongo/db/exec/delete.h
+++ b/src/mongo/db/exec/delete.h
@@ -70,6 +70,9 @@ struct DeleteStageParams {
 
     // Optional. When not null, delete metrics are recorded here.
     OpDebug* opDebug;
+
+    //additional msgs
+    BSONObj additional;
 };
 
 /**

--- a/src/mongo/db/exec/update.cpp
+++ b/src/mongo/db/exec/update.cpp
@@ -693,6 +693,7 @@ BSONObj UpdateStage::transformAndUpdate(const Snapshotted<BSONObj>& oldObj, Reco
                 args.update = logObj;
                 args.criteria = idQuery;
                 args.fromMigrate = request->isFromMigration();
+                args.additionalInfo = request->getAdditionalInfo();
                 StatusWith<RecordId> res = _collection->updateDocument(getOpCtx(),
                                                                        recordId,
                                                                        oldObj,
@@ -841,7 +842,7 @@ void UpdateStage::doInsert() {
         invariant(_collection);
         const bool enforceQuota = !request->isGod();
         uassertStatusOK(_collection->insertDocument(
-            getOpCtx(), newObj, _params.opDebug, enforceQuota, request->isFromMigration()));
+            getOpCtx(), newObj, _params.opDebug, request->getAdditionalInfo(), enforceQuota, request->isFromMigration()));
 
         // Technically, we should save/restore state here, but since we are going to return
         // immediately after, it would just be wasted work.

--- a/src/mongo/db/introspect.cpp
+++ b/src/mongo/db/introspect.cpp
@@ -144,7 +144,7 @@ void profile(OperationContext* txn, NetworkOp op) {
             if (coll) {
                 WriteUnitOfWork wuow(txn);
                 OpDebug* const nullOpDebug = nullptr;
-                coll->insertDocument(txn, p, nullOpDebug, false);
+                coll->insertDocument(txn, p, nullOpDebug, BSONObj(), false);
                 wuow.commit();
 
                 break;

--- a/src/mongo/db/op_observer.h
+++ b/src/mongo/db/op_observer.h
@@ -57,6 +57,9 @@ struct OplogUpdateEntryArgs {
 
     // True if this update comes from a chunk migration.
     bool fromMigrate;
+
+    //
+    BSONObj additionalInfo;
 };
 
 class OpObserver {
@@ -79,6 +82,7 @@ public:
                            const NamespaceString& ns,
                            std::vector<BSONObj>::const_iterator begin,
                            std::vector<BSONObj>::const_iterator end,
+                           const std::vector<BSONObj>& vecAdditionalInfo,
                            bool fromMigrate) = 0;
     virtual void aboutToUpdate(OperationContext* txn,
                                const NamespaceString& ns,
@@ -101,7 +105,8 @@ public:
     virtual void onDelete(OperationContext* txn,
                           const NamespaceString& ns,
                           CollectionShardingState::DeleteState deleteState,
-                          bool fromMigrate) = 0;
+                          bool fromMigrate,
+                          const BSONObj& additionalInfo) = 0;
     virtual void onOpMessage(OperationContext* txn, const BSONObj& msgObj) = 0;
     virtual void onCreateCollection(OperationContext* txn,
                                     const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_impl.cpp
+++ b/src/mongo/db/op_observer_impl.cpp
@@ -52,7 +52,7 @@ void OpObserverImpl::onCreateIndex(OperationContext* txn,
                                    const std::string& ns,
                                    BSONObj indexDoc,
                                    bool fromMigrate) {
-    repl::logOp(txn, "i", ns.c_str(), indexDoc, nullptr, fromMigrate);
+    repl::logOp(txn, "i", ns.c_str(), indexDoc, nullptr, fromMigrate, BSONObj());
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "i", ns.c_str(), indexDoc, nullptr);
 
@@ -85,8 +85,9 @@ void OpObserverImpl::onInserts(OperationContext* txn,
                                const NamespaceString& nss,
                                std::vector<BSONObj>::const_iterator begin,
                                std::vector<BSONObj>::const_iterator end,
+                               const std::vector<BSONObj>& vecAdditionalInfo,
                                bool fromMigrate) {
-    repl::logOps(txn, "i", nss, begin, end, fromMigrate);
+    repl::logOps(txn, "i", nss, begin, end, fromMigrate, vecAdditionalInfo);
 
     auto css = CollectionShardingState::get(txn, nss.ns());
     const char* ns = nss.ns().c_str();
@@ -147,7 +148,7 @@ void OpObserverImpl::onUpdate(OperationContext* txn, const OplogUpdateEntryArgs&
         return;
     }
 
-    repl::logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria, args.fromMigrate);
+    repl::logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria, args.fromMigrate, args.additionalInfo);
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria);
 
@@ -194,11 +195,12 @@ CollectionShardingState::DeleteState OpObserverImpl::aboutToDelete(OperationCont
 void OpObserverImpl::onDelete(OperationContext* txn,
                               const NamespaceString& ns,
                               CollectionShardingState::DeleteState deleteState,
-                              bool fromMigrate) {
+                              bool fromMigrate,
+                              const BSONObj& additionalInfo) {
     if (deleteState.idDoc.isEmpty())
         return;
 
-    repl::logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr, fromMigrate);
+    repl::logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr, fromMigrate, additionalInfo);
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr);
 
@@ -220,7 +222,7 @@ void OpObserverImpl::onDelete(OperationContext* txn,
 }
 
 void OpObserverImpl::onOpMessage(OperationContext* txn, const BSONObj& msgObj) {
-    repl::logOp(txn, "n", "", msgObj, nullptr, false);
+    repl::logOp(txn, "n", "", msgObj, nullptr, false, BSONObj());
 }
 
 void OpObserverImpl::onCreateCollection(OperationContext* txn,
@@ -246,7 +248,7 @@ void OpObserverImpl::onCreateCollection(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);
@@ -261,7 +263,7 @@ void OpObserverImpl::onCollMod(OperationContext* txn,
 
     if (!NamespaceString(NamespaceString(dbName).db(), coll).isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), collModCmd, nullptr, false);
+        repl::logOp(txn, "c", dbName.c_str(), collModCmd, nullptr, false, BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), collModCmd, nullptr);
@@ -271,7 +273,7 @@ void OpObserverImpl::onCollMod(OperationContext* txn,
 void OpObserverImpl::onDropDatabase(OperationContext* txn, const std::string& dbName) {
     BSONObj cmdObj = BSON("dropDatabase" << 1);
 
-    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
 
     if (NamespaceString(dbName).db() == FeatureCompatibilityVersion::kDatabase) {
         FeatureCompatibilityVersion::onDropCollection(txn);
@@ -288,7 +290,7 @@ void OpObserverImpl::onDropCollection(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
     }
 
     if (collectionName.coll() == DurableViewCatalog::viewsCollectionName()) {
@@ -310,7 +312,7 @@ void OpObserverImpl::onDropCollection(OperationContext* txn,
 void OpObserverImpl::onDropIndex(OperationContext* txn,
                                  const std::string& dbName,
                                  const BSONObj& idxDescriptor) {
-    repl::logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr, false);
+    repl::logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr, false, BSONObj());
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr);
     logOpForDbHash(txn, dbName.c_str());
@@ -328,7 +330,7 @@ void OpObserverImpl::onRenameCollection(OperationContext* txn,
                                 << "dropTarget"
                                 << dropTarget);
 
-    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
     if (fromCollection.isSystemDotViews())
         DurableViewCatalog::onExternalChange(txn, fromCollection);
     if (toCollection.isSystemDotViews())
@@ -341,7 +343,7 @@ void OpObserverImpl::onRenameCollection(OperationContext* txn,
 void OpObserverImpl::onApplyOps(OperationContext* txn,
                                 const std::string& dbName,
                                 const BSONObj& applyOpCmd) {
-    repl::logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr, false);
+    repl::logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr, false, BSONObj());
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr);
     logOpForDbHash(txn, dbName.c_str());
@@ -355,7 +357,7 @@ void OpObserverImpl::onConvertToCapped(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);
@@ -368,7 +370,7 @@ void OpObserverImpl::onEmptyCapped(OperationContext* txn, const NamespaceString&
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false);
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);

--- a/src/mongo/db/op_observer_impl.cpp
+++ b/src/mongo/db/op_observer_impl.cpp
@@ -52,7 +52,7 @@ void OpObserverImpl::onCreateIndex(OperationContext* txn,
                                    const std::string& ns,
                                    BSONObj indexDoc,
                                    bool fromMigrate) {
-    repl::logOp(txn, "i", ns.c_str(), indexDoc, nullptr, fromMigrate, BSONObj());
+    repl::logOp(txn, "i", ns.c_str(), indexDoc, nullptr, fromMigrate, BSONObj(), BSONObj());
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "i", ns.c_str(), indexDoc, nullptr);
 
@@ -148,7 +148,7 @@ void OpObserverImpl::onUpdate(OperationContext* txn, const OplogUpdateEntryArgs&
         return;
     }
 
-    repl::logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria, args.fromMigrate, args.additionalInfo);
+    repl::logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria, args.fromMigrate, args.additionalInfo, BSONObj());
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "u", args.ns.c_str(), args.update, &args.criteria);
 
@@ -180,6 +180,7 @@ CollectionShardingState::DeleteState OpObserverImpl::aboutToDelete(OperationCont
     BSONElement idElement = doc["_id"];
     if (!idElement.eoo()) {
         deleteState.idDoc = idElement.wrap();
+        deleteState.objWithoutId = doc.removeField("_id");
     }
 
     auto css = CollectionShardingState::get(txn, ns.ns());
@@ -200,7 +201,7 @@ void OpObserverImpl::onDelete(OperationContext* txn,
     if (deleteState.idDoc.isEmpty())
         return;
 
-    repl::logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr, fromMigrate, additionalInfo);
+    repl::logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr, fromMigrate, additionalInfo, deleteState.objWithoutId);
     AuthorizationManager::get(txn->getServiceContext())
         ->logOp(txn, "d", ns.ns().c_str(), deleteState.idDoc, nullptr);
 
@@ -222,7 +223,7 @@ void OpObserverImpl::onDelete(OperationContext* txn,
 }
 
 void OpObserverImpl::onOpMessage(OperationContext* txn, const BSONObj& msgObj) {
-    repl::logOp(txn, "n", "", msgObj, nullptr, false, BSONObj());
+    repl::logOp(txn, "n", "", msgObj, nullptr, false, BSONObj(), BSONObj());
 }
 
 void OpObserverImpl::onCreateCollection(OperationContext* txn,
@@ -248,7 +249,7 @@ void OpObserverImpl::onCreateCollection(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);
@@ -263,7 +264,7 @@ void OpObserverImpl::onCollMod(OperationContext* txn,
 
     if (!NamespaceString(NamespaceString(dbName).db(), coll).isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), collModCmd, nullptr, false, BSONObj());
+        repl::logOp(txn, "c", dbName.c_str(), collModCmd, nullptr, false, BSONObj(), BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), collModCmd, nullptr);
@@ -273,7 +274,7 @@ void OpObserverImpl::onCollMod(OperationContext* txn,
 void OpObserverImpl::onDropDatabase(OperationContext* txn, const std::string& dbName) {
     BSONObj cmdObj = BSON("dropDatabase" << 1);
 
-    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
 
     if (NamespaceString(dbName).db() == FeatureCompatibilityVersion::kDatabase) {
         FeatureCompatibilityVersion::onDropCollection(txn);
@@ -290,7 +291,7 @@ void OpObserverImpl::onDropCollection(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
     }
 
     if (collectionName.coll() == DurableViewCatalog::viewsCollectionName()) {
@@ -312,7 +313,7 @@ void OpObserverImpl::onDropCollection(OperationContext* txn,
 void OpObserverImpl::onDropIndex(OperationContext* txn,
                                  const std::string& dbName,
                                  const BSONObj& idxDescriptor) {
-    repl::logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr, false, BSONObj());
+    repl::logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr, false, BSONObj(), BSONObj());
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), idxDescriptor, nullptr);
     logOpForDbHash(txn, dbName.c_str());
@@ -330,7 +331,7 @@ void OpObserverImpl::onRenameCollection(OperationContext* txn,
                                 << "dropTarget"
                                 << dropTarget);
 
-    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+    repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
     if (fromCollection.isSystemDotViews())
         DurableViewCatalog::onExternalChange(txn, fromCollection);
     if (toCollection.isSystemDotViews())
@@ -343,7 +344,7 @@ void OpObserverImpl::onRenameCollection(OperationContext* txn,
 void OpObserverImpl::onApplyOps(OperationContext* txn,
                                 const std::string& dbName,
                                 const BSONObj& applyOpCmd) {
-    repl::logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr, false, BSONObj());
+    repl::logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr, false, BSONObj(), BSONObj());
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), applyOpCmd, nullptr);
     logOpForDbHash(txn, dbName.c_str());
@@ -357,7 +358,7 @@ void OpObserverImpl::onConvertToCapped(OperationContext* txn,
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);
@@ -370,7 +371,7 @@ void OpObserverImpl::onEmptyCapped(OperationContext* txn, const NamespaceString&
 
     if (!collectionName.isSystemDotProfile()) {
         // do not replicate system.profile modifications
-        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj());
+        repl::logOp(txn, "c", dbName.c_str(), cmdObj, nullptr, false, BSONObj(), BSONObj());
     }
 
     getGlobalAuthorizationManager()->logOp(txn, "c", dbName.c_str(), cmdObj, nullptr);

--- a/src/mongo/db/op_observer_impl.h
+++ b/src/mongo/db/op_observer_impl.h
@@ -1,3 +1,11 @@
+/*
+ * @Author: your name
+ * @Date: 2020-09-10 10:33:38
+ * @LastEditTime: 2022-03-02 19:10:09
+ * @LastEditors: Please set LastEditors
+ * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ * @FilePath: /src/mongo/db/op_observer_impl.h
+ */
 /**
  *    Copyright 2016 MongoDB Inc.
  *
@@ -52,6 +60,7 @@ public:
                    const NamespaceString& ns,
                    std::vector<BSONObj>::const_iterator begin,
                    std::vector<BSONObj>::const_iterator end,
+                   const std::vector<BSONObj>& vecAdditionalInfo,
                    bool fromMigrate) override;
     void aboutToUpdate(OperationContext* txn,
                        const NamespaceString& ns,
@@ -65,7 +74,8 @@ public:
     void onDelete(OperationContext* txn,
                   const NamespaceString& ns,
                   CollectionShardingState::DeleteState deleteState,
-                  bool fromMigrate) override;
+                  bool fromMigrate,
+                  const BSONObj& additionalInfo) override;
     void onOpMessage(OperationContext* txn, const BSONObj& msgObj) override;
     void onCreateCollection(OperationContext* txn,
                             const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_noop.cpp
+++ b/src/mongo/db/op_observer_noop.cpp
@@ -44,6 +44,7 @@ void OpObserverNoop::onInserts(OperationContext*,
                                const NamespaceString&,
                                std::vector<BSONObj>::const_iterator,
                                std::vector<BSONObj>::const_iterator,
+                               const std::vector<BSONObj>& vecAdditionalInfo,
                                bool) {}
 
 void OpObserverNoop::aboutToUpdate(OperationContext* txn,
@@ -63,7 +64,8 @@ CollectionShardingState::DeleteState OpObserverNoop::aboutToDelete(OperationCont
 void OpObserverNoop::onDelete(OperationContext*,
                               const NamespaceString&,
                               CollectionShardingState::DeleteState,
-                              bool) {}
+                              bool,
+                              const BSONObj& additionalInfo) {}
 
 void OpObserverNoop::onOpMessage(OperationContext*, const BSONObj&) {}
 

--- a/src/mongo/db/op_observer_noop.h
+++ b/src/mongo/db/op_observer_noop.h
@@ -1,3 +1,11 @@
+/*
+ * @Author: your name
+ * @Date: 2020-09-10 10:33:38
+ * @LastEditTime: 2022-03-02 19:10:20
+ * @LastEditors: Please set LastEditors
+ * @Description: 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ * @FilePath: /src/mongo/db/op_observer_noop.h
+ */
 /**
  *    Copyright 2016 MongoDB Inc.
  *
@@ -52,6 +60,7 @@ public:
                    const NamespaceString& ns,
                    std::vector<BSONObj>::const_iterator begin,
                    std::vector<BSONObj>::const_iterator end,
+                   const std::vector<BSONObj>& vecAdditionalInfo,
                    bool fromMigrate) override;
     void aboutToUpdate(OperationContext* txn,
                        const NamespaceString& ns,
@@ -65,7 +74,8 @@ public:
     void onDelete(OperationContext* txn,
                   const NamespaceString& ns,
                   CollectionShardingState::DeleteState deleteState,
-                  bool fromMigrate) override;
+                  bool fromMigrate,
+                  const BSONObj& additionalInfo) override;
     void onOpMessage(OperationContext* txn, const BSONObj& msgObj) override;
     void onCreateCollection(OperationContext* txn,
                             const NamespaceString& collectionName,

--- a/src/mongo/db/ops/delete_request.h
+++ b/src/mongo/db/ops/delete_request.h
@@ -80,6 +80,9 @@ public:
     void setYieldPolicy(PlanExecutor::YieldPolicy yieldPolicy) {
         _yieldPolicy = yieldPolicy;
     }
+    void setAdditionalInfo(const BSONObj& additionalInfo) {
+        _additionalInfo = additionalInfo;
+    }
 
     const NamespaceString& getNamespaceString() const {
         return _nsString;
@@ -114,6 +117,9 @@ public:
     PlanExecutor::YieldPolicy getYieldPolicy() const {
         return _yieldPolicy;
     }
+    const BSONObj& getAdditionalInfo() const {
+        return _additionalInfo;
+    }
 
 private:
     const NamespaceString& _nsString;
@@ -127,6 +133,7 @@ private:
     bool _isExplain;
     bool _returnDeleted;
     PlanExecutor::YieldPolicy _yieldPolicy;
+    BSONObj _additionalInfo;
 };
 
 }  // namespace mongo

--- a/src/mongo/db/ops/update_request.h
+++ b/src/mongo/db/ops/update_request.h
@@ -184,6 +184,14 @@ public:
         return _yieldPolicy;
     }
 
+    inline void setAdditionalInfo(const BSONObj& additionalInfo) {
+        _additionalInfo = additionalInfo;
+    }
+
+    inline const BSONObj& getAdditionalInfo() const {
+        return _additionalInfo;
+    }
+
     const std::string toString() const {
         return str::stream() << " query: " << _query << " projection: " << _proj
                              << " sort: " << _sort << " collation: " << _collation
@@ -248,6 +256,9 @@ private:
 
     // Whether or not the update should yield. Defaults to YIELD_MANUAL.
     PlanExecutor::YieldPolicy _yieldPolicy;
+
+    BSONObj _additionalInfo;
+            
 };
 
 }  // namespace mongo

--- a/src/mongo/db/ops/write_ops.h
+++ b/src/mongo/db/ops/write_ops.h
@@ -53,6 +53,7 @@ struct ParsedWriteOp {
  */
 struct InsertOp : ParsedWriteOp {
     std::vector<BSONObj> documents;
+    std::vector<BSONObj> vecAdditional;
 };
 
 /**
@@ -65,6 +66,7 @@ struct UpdateOp : ParsedWriteOp {
         BSONObj collation;
         bool multi = false;
         bool upsert = false;
+        BSONObj additionalInfo;
     };
 
     std::vector<SingleUpdate> updates;
@@ -78,6 +80,7 @@ struct DeleteOp : ParsedWriteOp {
         BSONObj query;
         BSONObj collation;
         bool multi = true;
+        BSONObj additionalInfo;
     };
 
     std::vector<SingleDelete> deletes;

--- a/src/mongo/db/ops/write_ops_exec.cpp
+++ b/src/mongo/db/ops/write_ops_exec.cpp
@@ -303,12 +303,13 @@ static void insertDocuments(OperationContext* txn,
                             Collection* collection,
                             std::vector<BSONObj>::const_iterator begin,
                             std::vector<BSONObj>::const_iterator end,
-                            bool fromMigrate) {
+                            bool fromMigrate,
+                            const std::vector<BSONObj>& vecAdditionalInfo) {
     // Intentionally not using a WRITE_CONFLICT_RETRY_LOOP. That is handled by the caller so it can
     // react to oversized batches.
     WriteUnitOfWork wuow(txn);
     uassertStatusOK(collection->insertDocuments(
-        txn, begin, end, &CurOp::get(txn)->debug(), /*enforceQuota*/ true, fromMigrate));
+        txn, begin, end, &CurOp::get(txn)->debug(), vecAdditionalInfo, /*enforceQuota*/ true, fromMigrate));
     wuow.commit();
 }
 
@@ -354,7 +355,7 @@ static bool insertBatchAndHandleErrors(OperationContext* txn,
             // See Collection::_insertDocuments for why we do all capped inserts one-at-a-time.
             lastOpFixer->startingOp();
             insertDocuments(
-                txn, collection->getCollection(), batch.begin(), batch.end(), fromMigrate);
+                txn, collection->getCollection(), batch.begin(), batch.end(), fromMigrate, wholeOp.vecAdditional);
             lastOpFixer->finishedOpSuccessfully();
             globalOpCounters.gotInserts(batch.size());
             std::fill_n(
@@ -370,6 +371,7 @@ static bool insertBatchAndHandleErrors(OperationContext* txn,
 
     // Try to insert the batch one-at-a-time. This path is executed both for singular batches, and
     // for batches that failed all-at-once inserting.
+    int index_additional_info = 0;
     for (auto it = batch.begin(); it != batch.end(); ++it) {
         globalOpCounters.gotInsert();
         try {
@@ -378,10 +380,12 @@ static bool insertBatchAndHandleErrors(OperationContext* txn,
                     if (!collection)
                         acquireCollection();
                     lastOpFixer->startingOp();
-                    insertDocuments(txn, collection->getCollection(), it, it + 1, fromMigrate);
+                    std::vector<BSONObj> vecAdditionalInfo(1, wholeOp.vecAdditional[index_additional_info]);
+                    insertDocuments(txn, collection->getCollection(), it, it + 1, fromMigrate, vecAdditionalInfo);
                     lastOpFixer->finishedOpSuccessfully();
                     out->results.emplace_back(WriteResult::SingleResult{1});
                     curOp.debug().ninserted++;
+                    index_additional_info++;
                 } catch (...) {
                     // Release the lock following any error. Among other things, this ensures that
                     // we don't sleep in the WCE retry loop with the lock held.
@@ -502,6 +506,7 @@ static WriteResult::SingleResult performSingleUpdateOp(OperationContext* txn,
     request.setMulti(op.multi);
     request.setUpsert(op.upsert);
     request.setYieldPolicy(PlanExecutor::YIELD_AUTO);  // ParsedUpdate overrides this for $isolated.
+    request.setAdditionalInfo(op.additionalInfo);
 
     ParsedUpdate parsedUpdate(txn, &request);
     uassertStatusOK(parsedUpdate.parseRequest());
@@ -621,6 +626,7 @@ static WriteResult::SingleResult performSingleDeleteOp(OperationContext* txn,
     request.setCollation(op.collation);
     request.setMulti(op.multi);
     request.setYieldPolicy(PlanExecutor::YIELD_AUTO);  // ParsedDelete overrides this for $isolated.
+    request.setAdditionalInfo(op.additionalInfo);
 
     ParsedDelete parsedDelete(txn, &request);
     uassertStatusOK(parsedDelete.parseRequest());
@@ -702,7 +708,7 @@ WriteResult performDeletes(OperationContext* txn, const DeleteOp& wholeOp) {
                 break;
         }
     }
-
+    
     return out;
 }
 

--- a/src/mongo/db/ops/write_ops_parsers.cpp
+++ b/src/mongo/db/ops/write_ops_parsers.cpp
@@ -25,7 +25,7 @@
  *    exception statement from all source files in the program, then also delete
  *    it in the license file.
  */
-
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kWrite
 #include "mongo/platform/basic.h"
 
 #include "mongo/db/ops/write_ops_parsers.h"
@@ -36,8 +36,11 @@
 #include "mongo/db/dbmessage.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/mongoutils/str.h"
+#include "mongo/util/log.h"
+#include "mongo/db/bson/trace_additional_from_query.h"
 
 namespace mongo {
+namespace tq = ::mongo::trace_query;
 namespace {
 
 // The specified limit to the number of operations that can be included in a single write command.
@@ -130,7 +133,11 @@ InsertOp parseInsertCommand(StringData dbName, const BSONObj& cmd) {
     checkBSONType(Array, documents);
     for (auto doc : documents.Obj()) {
         checkTypeInArray(Object, doc, documents);
-        op.documents.push_back(doc.Obj());
+        auto doc_no_additional_info = doc.Obj();
+        BSONObj doc_additional;
+        tq::traceAdditionalInfoFromQuery(doc_no_additional_info, doc_additional);
+        op.documents.push_back(doc_no_additional_info);
+        op.vecAdditional.push_back(doc_additional);
     }
     checkOpCountForCommand(op.documents.size());
 
@@ -161,6 +168,7 @@ UpdateOp parseUpdateCommand(StringData dbName, const BSONObj& cmd) {
                 haveQ = true;
                 checkBSONType(Object, field);
                 update.query = field.Obj();
+                tq::traceAdditionalInfoFromQuery(update.query, update.additionalInfo);
             } else if (fieldName == "u") {
                 haveU = true;
                 checkBSONType(Object, field);
@@ -204,6 +212,7 @@ DeleteOp parseDeleteCommand(StringData dbName, const BSONObj& cmd) {
                 haveQ = true;
                 checkBSONType(Object, field);
                 del.query = field.Obj();
+                tq::traceAdditionalInfoFromQuery(del.query, del.additionalInfo);
             } else if (fieldName == "collation") {
                 checkBSONType(Object, field);
                 del.collation = field.Obj();
@@ -244,7 +253,11 @@ InsertOp parseLegacyInsert(const Message& msgRaw) {
     op.continueOnError = msg.reservedField() & InsertOption_ContinueOnError;
     uassert(ErrorCodes::InvalidLength, "Need at least one object to insert", msg.moreJSObjs());
     while (msg.moreJSObjs()) {
-        op.documents.push_back(msg.nextJsObj());
+        auto insertMsg = msg.nextJsObj();
+        BSONObj additional;
+        trace_query::traceAdditionalInfoFromQuery(insertMsg, additional);
+        op.vecAdditional.push_back(additional);
+        op.documents.push_back(insertMsg);
     }
     // There is no limit on the number of inserts in a legacy batch.
 
@@ -265,6 +278,7 @@ UpdateOp parseLegacyUpdate(const Message& msgRaw) {
     singleUpdate.multi = flags & UpdateOption_Multi;
     singleUpdate.query = msg.nextJsObj();
     singleUpdate.update = msg.nextJsObj();
+    tq::traceAdditionalInfoFromQuery(singleUpdate.query, singleUpdate.additionalInfo);
 
     return op;
 }
@@ -281,6 +295,7 @@ DeleteOp parseLegacyDelete(const Message& msgRaw) {
     const int flags = msg.pullInt();
     singleDelete.multi = !(flags & RemoveOption_JustOne);
     singleDelete.query = msg.nextJsObj();
+    tq::traceAdditionalInfoFromQuery(singleDelete.query, singleDelete.additionalInfo);
 
     return op;
 }

--- a/src/mongo/db/query/find_and_modify_request.cpp
+++ b/src/mongo/db/query/find_and_modify_request.cpp
@@ -34,9 +34,12 @@
 #include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/bson/util/bson_extract.h"
 #include "mongo/db/write_concern.h"
+#include "mongo/db/commands.h"
+#include "mongo/db/bson/trace_additional_from_query.h"
+
 
 namespace mongo {
-
+namespace tq = ::mongo::trace_query;
 namespace {
 const char kCmdName[] = "findAndModify";
 const char kQueryField[] = "query";
@@ -152,12 +155,15 @@ StatusWith<FindAndModifyRequest> FindAndModifyRequest::parseFromBSON(NamespaceSt
                     " 'remove' always returns the deleted document"};
         }
     }
+    BSONObj additionalMsg;
+    tq::traceAdditionalInfoFromQuery(query, additionalMsg);
 
     FindAndModifyRequest request(std::move(fullNs), query, updateObj);
     request._isRemove = isRemove;
     request.setFieldProjection(fields);
     request.setSort(sort);
     request.setCollation(collation);
+    request.setAdditionalInfo(additionalMsg);
 
     if (!isRemove) {
         request.setShouldReturnNew(shouldReturnNew);
@@ -191,6 +197,10 @@ void FindAndModifyRequest::setUpsert(bool upsert) {
 
 void FindAndModifyRequest::setWriteConcern(WriteConcernOptions writeConcern) {
     _writeConcern = std::move(writeConcern);
+}
+
+void FindAndModifyRequest::setAdditionalInfo(BSONObj additionalInfo){
+    _additionalInfo = additionalInfo.getOwned();
 }
 
 const NamespaceString& FindAndModifyRequest::getNamespaceString() const {
@@ -228,4 +238,9 @@ bool FindAndModifyRequest::isUpsert() const {
 bool FindAndModifyRequest::isRemove() const {
     return _isRemove;
 }
+
+BSONObj FindAndModifyRequest::getAdditionalInfo() const {
+    return _additionalInfo.value_or(BSONObj());
+}
+
 }

--- a/src/mongo/db/query/find_and_modify_request.h
+++ b/src/mongo/db/query/find_and_modify_request.h
@@ -102,6 +102,8 @@ public:
     // Not implemented. Use extractWriteConcern() to get the setting instead.
     WriteConcernOptions getWriteConcern() const;
 
+    BSONObj getAdditionalInfo() const;
+
     //
     // Setters for update type request only.
     //
@@ -140,6 +142,8 @@ public:
      */
     void setWriteConcern(WriteConcernOptions writeConcern);
 
+    void setAdditionalInfo(BSONObj additionalInfo);
+
 private:
     /**
      * Creates a new FindAndModifyRequest with the required fields.
@@ -152,6 +156,9 @@ private:
 
     // Required for updates
     const BSONObj _updateObj;
+
+    // Required additional msgs
+    boost::optional<BSONObj> _additionalInfo;
 
     boost::optional<bool> _isUpsert;
     boost::optional<BSONObj> _fieldProjection;

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -718,6 +718,7 @@ StatusWith<unique_ptr<PlanExecutor>> getExecutorDelete(OperationContext* txn,
     deleteStageParams.returnDeleted = request->shouldReturnDeleted();
     deleteStageParams.sort = request->getSort();
     deleteStageParams.opDebug = opDebug;
+    deleteStageParams.additional = request->getAdditionalInfo();
 
     unique_ptr<WorkingSet> ws = make_unique<WorkingSet>();
     const PlanExecutor::YieldPolicy policy = parsedDelete->yieldPolicy();

--- a/src/mongo/db/repl/collection_bulk_loader_impl.cpp
+++ b/src/mongo/db/repl/collection_bulk_loader_impl.cpp
@@ -145,7 +145,7 @@ Status CollectionBulkLoaderImpl::insertDocuments(const std::vector<BSONObj>::con
                 } else {
                     // For capped collections, we use regular insertDocument, which will update
                     // pre-existing indexes.
-                    const auto status = _coll->insertDocument(txn, *iter, nullptr, false, false);
+                    const auto status = _coll->insertDocument(txn, *iter, nullptr, BSONObj(), false, false);
                     if (!status.isOK()) {
                         return status;
                     }
@@ -207,6 +207,7 @@ Status CollectionBulkLoaderImpl::commit() {
                         _coll->deleteDocument(_txn,
                                               it,
                                               nullptr /** OpDebug **/,
+                                              BSONObj(),/** additional info**/
                                               false /* fromMigrate */,
                                               true /* noWarn */);
                         wunit.commit();

--- a/src/mongo/db/repl/oplog.cpp
+++ b/src/mongo/db/repl/oplog.cpp
@@ -275,7 +275,8 @@ OplogDocWriter _logOpWriter(OperationContext* txn,
                             bool fromMigrate,
                             OpTime optime,
                             long long hashNew,
-                            const BSONObj& additional) {
+                            const BSONObj& additional,
+                            const BSONObj& docWithoutId) {
     BSONObjBuilder b(256);
 
     b.append("ts", optime.getTimestamp());
@@ -292,6 +293,9 @@ OplogDocWriter _logOpWriter(OperationContext* txn,
 
     if(!additional.isEmpty()){
         b.append("additional", additional);
+    }
+    if(!docWithoutId.isEmpty() && !fromMigrate){ //fromMigrate的delete不带原始信息
+        b.append("fullfields", docWithoutId);
     }
     
     return OplogDocWriter(OplogDocWriter(b.obj(), obj));
@@ -399,7 +403,8 @@ void logOp(OperationContext* txn,
            const BSONObj& obj,
            const BSONObj* o2,
            bool fromMigrate,
-           const BSONObj& additional) {
+           const BSONObj& additional,
+           const BSONObj& docWithoutId) {
     ReplicationCoordinator::Mode replMode = ReplicationCoordinator::get(txn)->getReplicationMode();
     NamespaceString nss(ns);
     if (oplogDisabled(txn, replMode, nss))
@@ -411,7 +416,7 @@ void logOp(OperationContext* txn,
     Lock::CollectionLock lock(txn->lockState(), _oplogCollectionName, MODE_IX);
     OplogSlot slot;
     getNextOpTime(txn, oplog, replCoord, replMode, 1, &slot);
-    auto writer = _logOpWriter(txn, opstr, nss, obj, o2, fromMigrate, slot.opTime, slot.hash, additional);
+    auto writer = _logOpWriter(txn, opstr, nss, obj, o2, fromMigrate, slot.opTime, slot.hash, additional, docWithoutId);
     const DocWriter* basePtr = &writer;
     _logOpsInner(txn, nss, &basePtr, 1, oplog, replMode, slot.opTime);
 }
@@ -444,7 +449,7 @@ void logOps(OperationContext* txn,
     for (size_t i = 0; i < count; i++) {
         auto additionInfo = vecAdditionalInfo[i];
         writers.emplace_back(_logOpWriter(
-            txn, opstr, nss, begin[i], NULL, fromMigrate, slots[i].opTime, slots[i].hash, additionInfo));
+            txn, opstr, nss, begin[i], NULL, fromMigrate, slots[i].opTime, slots[i].hash, additionInfo, BSONObj()));
     }
 
     std::unique_ptr<DocWriter const* []> basePtrs(new DocWriter const*[count]);

--- a/src/mongo/db/repl/oplog.cpp
+++ b/src/mongo/db/repl/oplog.cpp
@@ -274,7 +274,8 @@ OplogDocWriter _logOpWriter(OperationContext* txn,
                             const BSONObj* o2,
                             bool fromMigrate,
                             OpTime optime,
-                            long long hashNew) {
+                            long long hashNew,
+                            const BSONObj& additional) {
     BSONObjBuilder b(256);
 
     b.append("ts", optime.getTimestamp());
@@ -289,6 +290,10 @@ OplogDocWriter _logOpWriter(OperationContext* txn,
     if (o2)
         b.append("o2", *o2);
 
+    if(!additional.isEmpty()){
+        b.append("additional", additional);
+    }
+    
     return OplogDocWriter(OplogDocWriter(b.obj(), obj));
 }
 }  // end anon namespace
@@ -387,12 +392,14 @@ void _logOpsInner(OperationContext* txn,
     });
 }
 
+
 void logOp(OperationContext* txn,
            const char* opstr,
            const char* ns,
            const BSONObj& obj,
            const BSONObj* o2,
-           bool fromMigrate) {
+           bool fromMigrate,
+           const BSONObj& additional) {
     ReplicationCoordinator::Mode replMode = ReplicationCoordinator::get(txn)->getReplicationMode();
     NamespaceString nss(ns);
     if (oplogDisabled(txn, replMode, nss))
@@ -404,7 +411,7 @@ void logOp(OperationContext* txn,
     Lock::CollectionLock lock(txn->lockState(), _oplogCollectionName, MODE_IX);
     OplogSlot slot;
     getNextOpTime(txn, oplog, replCoord, replMode, 1, &slot);
-    auto writer = _logOpWriter(txn, opstr, nss, obj, o2, fromMigrate, slot.opTime, slot.hash);
+    auto writer = _logOpWriter(txn, opstr, nss, obj, o2, fromMigrate, slot.opTime, slot.hash, additional);
     const DocWriter* basePtr = &writer;
     _logOpsInner(txn, nss, &basePtr, 1, oplog, replMode, slot.opTime);
 }
@@ -414,7 +421,8 @@ void logOps(OperationContext* txn,
             const NamespaceString& nss,
             std::vector<BSONObj>::const_iterator begin,
             std::vector<BSONObj>::const_iterator end,
-            bool fromMigrate) {
+            bool fromMigrate,
+            const std::vector<BSONObj>& vecAdditionalInfo) {
     ReplicationCoordinator* replCoord = ReplicationCoordinator::get(txn);
     ReplicationCoordinator::Mode replMode = replCoord->getReplicationMode();
 
@@ -423,6 +431,9 @@ void logOps(OperationContext* txn,
         return;
 
     const size_t count = end - begin;
+    if (count != vecAdditionalInfo.size()){
+       log() << "additional infos vector's size not equal count. vector.size()=" << vecAdditionalInfo.size() << ", count=" << count;
+    }
     std::vector<OplogDocWriter> writers;
     writers.reserve(count);
     Collection* oplog = getLocalOplogCollection(txn, _oplogCollectionName);
@@ -431,8 +442,9 @@ void logOps(OperationContext* txn,
     std::unique_ptr<OplogSlot[]> slots(new OplogSlot[count]);
     getNextOpTime(txn, oplog, replCoord, replMode, count, slots.get());
     for (size_t i = 0; i < count; i++) {
+        auto additionInfo = vecAdditionalInfo[i];
         writers.emplace_back(_logOpWriter(
-            txn, opstr, nss, begin[i], NULL, fromMigrate, slots[i].opTime, slots[i].hash));
+            txn, opstr, nss, begin[i], NULL, fromMigrate, slots[i].opTime, slots[i].hash, additionInfo));
     }
 
     std::unique_ptr<DocWriter const* []> basePtrs(new DocWriter const*[count]);
@@ -820,8 +832,10 @@ Status applyOperation_inlock(OperationContext* txn,
         if (fieldO.type() == Array) {
             // Batched inserts.
             std::vector<BSONObj> insertObjs;
+            std::vector<BSONObj> vecAdditionalInfo;
             for (auto elem : fieldO.Obj()) {
                 insertObjs.push_back(elem.Obj());
+                vecAdditionalInfo.push_back(BSONObj());
             }
             uassert(ErrorCodes::OperationFailed,
                     str::stream() << "Failed to apply insert due to empty array element: "
@@ -830,7 +844,7 @@ Status applyOperation_inlock(OperationContext* txn,
             WriteUnitOfWork wuow(txn);
             OpDebug* const nullOpDebug = nullptr;
             Status status = collection->insertDocuments(
-                txn, insertObjs.begin(), insertObjs.end(), nullOpDebug, true);
+                txn, insertObjs.begin(), insertObjs.end(), nullOpDebug, vecAdditionalInfo, true);
             if (!status.isOK()) {
                 return status;
             }
@@ -865,7 +879,7 @@ Status applyOperation_inlock(OperationContext* txn,
             if (!needToDoUpsert) {
                 WriteUnitOfWork wuow(txn);
                 OpDebug* const nullOpDebug = nullptr;
-                auto status = collection->insertDocument(txn, o, nullOpDebug, true);
+                auto status = collection->insertDocument(txn, o, nullOpDebug, BSONObj(), true);
                 if (status.isOK()) {
                     wuow.commit();
                 } else if (status == ErrorCodes::DuplicateKey) {

--- a/src/mongo/db/repl/oplog.h
+++ b/src/mongo/db/repl/oplog.h
@@ -98,7 +98,8 @@ void logOp(OperationContext* txn,
            const BSONObj& obj,
            const BSONObj* o2,
            bool fromMigrate,
-           const BSONObj& additional);
+           const BSONObj& additional,
+           const BSONObj& docWithoutId);
 
 // Flush out the cached pointers to the local database and oplog.
 // Used by the closeDatabase command to ensure we don't cache closed things.

--- a/src/mongo/db/repl/oplog.h
+++ b/src/mongo/db/repl/oplog.h
@@ -86,7 +86,8 @@ void logOps(OperationContext* txn,
             const NamespaceString& nss,
             std::vector<BSONObj>::const_iterator begin,
             std::vector<BSONObj>::const_iterator end,
-            bool fromMigrate);
+            bool fromMigrate,
+            const std::vector<BSONObj>& vecAdditionalInfo);
 
 /* For 'u' records, 'obj' captures the mutation made to the object but not
  * the object itself. 'o2' captures the the criteria for the object that will be modified.
@@ -96,7 +97,8 @@ void logOp(OperationContext* txn,
            const char* ns,
            const BSONObj& obj,
            const BSONObj* o2,
-           bool fromMigrate);
+           bool fromMigrate,
+           const BSONObj& additional);
 
 // Flush out the cached pointers to the local database and oplog.
 // Used by the closeDatabase command to ensure we don't cache closed things.

--- a/src/mongo/db/repl/storage_interface_impl.cpp
+++ b/src/mongo/db/repl/storage_interface_impl.cpp
@@ -356,7 +356,9 @@ Status insertDocumentsSingleBatch(OperationContext* txn,
 
     WriteUnitOfWork wunit(txn);
     OpDebug* const nullOpDebug = nullptr;
-    auto status = collection->insertDocuments(txn, begin, end, nullOpDebug, false);
+    int count = end - begin;
+    std::vector<BSONObj> vecAdditionalInfo(count, BSONObj());
+    auto status = collection->insertDocuments(txn, begin, end, nullOpDebug, vecAdditionalInfo, false);
     if (!status.isOK()) {
         return status;
     }

--- a/src/mongo/db/repl/sync_tail.cpp
+++ b/src/mongo/db/repl/sync_tail.cpp
@@ -1060,7 +1060,7 @@ bool SyncTail::fetchAndInsertMissingDocument(OperationContext* txn, const BSONOb
         invariant(coll);
 
         OpDebug* const nullOpDebug = nullptr;
-        Status status = coll->insertDocument(txn, missingObj, nullOpDebug, true);
+        Status status = coll->insertDocument(txn, missingObj, nullOpDebug, BSONObj(), true);
         uassert(15917,
                 str::stream() << "Failed to insert missing document: " << status.toString(),
                 status.isOK());
@@ -1345,8 +1345,8 @@ StatusWith<OpTime> multiApply(OperationContext* txn,
         storage->setMinValidToAtLeast(txn, ops.back().getOpTime());
 
         applyOps(writerVectors, workerPool, applyOperation, &statusVector);
-    }
 
+    }
     // If any of the statuses is not ok, return error.
     for (auto& status : statusVector) {
         if (!status.isOK()) {

--- a/src/mongo/db/s/collection_metadata.cpp
+++ b/src/mongo/db/s/collection_metadata.cpp
@@ -58,7 +58,7 @@ CollectionMetadata::CollectionMetadata(const BSONObj& keyPattern,
     invariant(_collVersion >= _shardVersion);
 
     if (_chunksMap.empty()) {
-        //invariant(!_shardVersion.isSet());//这个判断应该去掉了，因为chunksMap为空，但是将一个shard的chunks都迁移空，shardVersion不会删掉，这就导致了_shardVersion不为空
+        invariant(!_shardVersion.isSet());//这个判断应该去掉了，因为chunksMap为空，但是将一个shard的chunks都迁移空，shardVersion不会删掉，这就导致了_shardVersion不为空
         return;
     }
 

--- a/src/mongo/db/s/collection_sharding_state.h
+++ b/src/mongo/db/s/collection_sharding_state.h
@@ -72,6 +72,9 @@ public:
         // True if the document being deleted belongs to a chunk which is currently being migrated
         // out of this shard.
         bool isMigrating = false;
+        
+        //deleted obj without _id
+        BSONObj objWithoutId;
     };
 
     /**

--- a/src/mongo/db/s/migration_destination_manager.cpp
+++ b/src/mongo/db/s/migration_destination_manager.cpp
@@ -738,6 +738,7 @@ void MigrationDestinationManager::_migrateDriver(OperationContext* txn,
 
                 assertNotAborted(opCtx);
 
+                InsertOp insertOp;
                 std::vector<BSONObj> toInsert;
                 while (it != arr.end() &&
                        (batchMaxCloned <= 0 || batchNumCloned < batchMaxCloned)) {
@@ -747,8 +748,9 @@ void MigrationDestinationManager::_migrateDriver(OperationContext* txn,
                     batchNumCloned++;
                     batchClonedBytes += docToClone.objsize();
                     it++;
+                    insertOp.vecAdditional.push_back(BSONObj());
                 }
-                InsertOp insertOp;
+                
                 insertOp.ns = _nss;
                 insertOp.documents = toInsert;
 
@@ -806,7 +808,7 @@ void MigrationDestinationManager::_migrateDriver(OperationContext* txn,
     repl::OpTime lastOpApplied = repl::ReplClientInfo::forClient(txn->getClient()).getLastOp();
 
     const BSONObj xferModsRequest = createTransferModsRequest(_nss, *_sessionId);
-
+    
     {
         // 4. Do bulk of mods
         setState(CATCHUP);
@@ -893,7 +895,7 @@ void MigrationDestinationManager::_migrateDriver(OperationContext* txn,
             return;
         }
     }
-
+    
     {
         // 5. Wait for commit
         setState(STEADY);

--- a/src/mongo/db/views/durable_view_catalog.cpp
+++ b/src/mongo/db/views/durable_view_catalog.cpp
@@ -144,7 +144,7 @@ void DurableViewCatalogImpl::upsert(OperationContext* txn,
     if (!id.isNormal() || !systemViews->findDoc(txn, id, &oldView)) {
         LOG(2) << "insert view " << view << " into " << _db->getSystemViewsName();
         uassertStatusOK(
-            systemViews->insertDocument(txn, view, &CurOp::get(txn)->debug(), enforceQuota));
+            systemViews->insertDocument(txn, view, &CurOp::get(txn)->debug(), BSONObj(), enforceQuota));
     } else {
         OplogUpdateEntryArgs args;
         args.ns = systemViewsNs.ns();
@@ -176,6 +176,6 @@ void DurableViewCatalogImpl::remove(OperationContext* txn, const NamespaceString
         return;
 
     LOG(2) << "remove view " << name << " from " << _db->getSystemViewsName();
-    systemViews->deleteDocument(txn, id, &CurOp::get(txn)->debug());
+    systemViews->deleteDocument(txn, id, &CurOp::get(txn)->debug(), BSONObj());
 }
 }  // namespace mongo

--- a/src/mongo/s/chunk_manager_inlock.cpp
+++ b/src/mongo/s/chunk_manager_inlock.cpp
@@ -107,6 +107,7 @@ ChunkManagerEX::ChunkManagerEX(std::shared_ptr<ChunkManagerEX> other,
         _topIndexMap = other->getTopIndexMap();
         _shardVersions = other->getShardVersionMap();
         //_shardVersionSize = _shardVersions.size();
+        _shardChunksCount = other->getShardChunksCountMap();
         _collectionVersion = other->getVersion();
     }
 }
@@ -413,7 +414,7 @@ ChunkVersion ChunkManagerEX::getVersion(const ShardId& shardName) const {
     if (it == _shardVersions.end()) {
         // Shards without explicitly tracked shard versions (meaning they have no chunks) always
         // have a version of (0, 0, epoch)
-        log() << "getVersion by shardname = " << shardName << ",not find";
+        log() << "getVersion by shardname = " << shardName << ",not find _collectionVersion.epoch()="<<_collectionVersion.epoch().toString() ;
         
         return ChunkVersion(0, 0, _collectionVersion.epoch());
     }
@@ -624,12 +625,22 @@ std::shared_ptr<ChunkManagerEX> ChunkManagerEX::build(const std::vector<ChunkTyp
 
         // Insert only the chunk itself
         chunkMap.insert(std::make_pair(chunkMaxKeyString, std::make_shared<Chunk>(chunk)));
+
+        //shardChunksCount build
+        auto itrShardChunksCount = _shardChunksCount.find(chunk.getShard());
+        if( itrShardChunksCount != _shardChunksCount.end()){
+            itrShardChunksCount->second ++ ;
+            LOG(5)<<"shardChunksCount build inc shardid="<<chunk.getShard().toString();
+        }else{
+            _shardChunksCount.emplace(chunk.getShard(), 1);
+            LOG(5)<<"shardChunksCount build emplace shardid="<<chunk.getShard().toString();
+        }
     }
 
     //构建_shardVdersionMap
     _shardVersions =
         _constructShardVersionMap(_collectionVersion.epoch(), chunkMap, _shardKeyOrdering);
-    log() << "_shardVersions size = " << _shardVersions.size();
+    log() << "_shardVersions size = " << _shardVersions.size()<<",_shardChunksCount size = " << _shardChunksCount.size();
 
     std::shared_ptr<ChunkMapEX> chunksSecondary = std::make_shared<ChunkMapEX>();
     int si = _maxSizeSingleChunksMap;
@@ -724,21 +735,36 @@ std::shared_ptr<ChunkManagerEX> ChunkManagerEX::makeUpdated(
         // not overlap max
         const auto high = itUpdate->second->upper_bound(chunkMaxKeyString);
 
+        for(auto it = low; it != high; it++){
+            auto shardChunksCount = _shardChunksCount.find(it->second->getShardId());
+            if(shardChunksCount != _shardChunksCount.end()){
+                shardChunksCount->second -- ;
+            }
+        }
+
         // Erase all chunks from the map, which overlap the chunk we got from the persistent store
         itUpdate->second->erase(low, high);
 
         // Insert only the chunk itself
         itUpdate->second->insert(std::make_pair(chunkMaxKeyString, std::make_shared<Chunk>(chunk)));
 
-
         auto shardVersionIt = _shardVersions.find(chunk.getShard());
         if (shardVersionIt == _shardVersions.end()) {
-            log() << "push shardid=" << chunk.getShard() << " to shardVersions. UpdateChunksMap";
+            LOG(5) << "push shardid=" << chunk.getShard() << " to shardVersions. UpdateChunksMap";
             _shardVersions.emplace(chunk.getShard(), chunk.getVersion());
+            if(_shardChunksCount.find(chunk.getShard()) == _shardChunksCount.end()){
+                _shardChunksCount.emplace(chunk.getShard(),1);//第一次有chunk到这个shard 初始值1
+            }else{//这时候也有可能是0的, 这里可以++ 也可以直接赋值1
+                _shardChunksCount[chunk.getShard()] ++;
+            }
         } else if (chunk.getVersion() > shardVersionIt->second) {
             shardVersionIt->second = chunk.getVersion();
+            _shardChunksCount[chunk.getShard()] ++;
+        }else{
+            _shardChunksCount[chunk.getShard()] ++;
         }
     }
+
     int change = 0;
     for (auto& it : changeChunksMap) {
         auto itIndex = _topIndexMap.find(it.first);
@@ -752,7 +778,20 @@ std::shared_ptr<ChunkManagerEX> ChunkManagerEX::makeUpdated(
         change++;
     }
     log() << "change cnt = " << change;
-    
+
+    //根据shardChunksCount 来判断要不要删除某个shard对shardVersion
+    for(auto itrChunksCount : _shardChunksCount){
+        if(itrChunksCount.second <= 0){
+            auto shardId = itrChunksCount.first;
+            log()<<" erase shard id = "<< shardId.toString();
+            _shardVersions.erase(shardId);
+        }
+    }
+
+    for(auto itrChunksCount : _shardChunksCount){
+        LOG(5)<<"print shardChunksCount shardid = "<<itrChunksCount.first<<", count="<<itrChunksCount.second;
+    }
+
     _collectionVersion = collectionVersion;
     log() << "makeUpdated time=" << timer.millis() << "ms";
     return shared_from_this();

--- a/src/mongo/s/chunk_manager_inlock.h
+++ b/src/mongo/s/chunk_manager_inlock.h
@@ -62,6 +62,8 @@ using ChunkMapEX = std::map<std::string, std::shared_ptr<Chunk>>;
 // Map from a shard is to the max chunk version on that shard
 using ShardVersionMapEX = std::map<ShardId, ChunkVersion>;
 
+using ShardChunksCountMap = std::map<ShardId, int>;
+
 using TopIndexMap = std::map<std::string, std::shared_ptr<ChunkMapEX>>;
 
 class CanonicalQuery;
@@ -241,6 +243,7 @@ public:
     //print true时，打印整个路由信息到日志
     std::shared_ptr<IteratorChunks> iteratorChunks(int start, int limit, bool print) const;
 
+    ShardChunksCountMap getShardChunksCountMap(){return _shardChunksCount;}
 private:
     friend class CollectionRoutingDataLoader;
 
@@ -305,6 +308,8 @@ private:
     ShardVersionMapEX _shardVersions;
 
     std::atomic<uint64_t> _shardVersionSize;
+
+    ShardChunksCountMap _shardChunksCount;
 
 
     // Max version across all chunks


### PR DESCRIPTION
1.oplog添加附加信息 
2.二级路由shard迁移空的bug修复，代码集中在chunk_manager_inlock.h chunk_manager_inlock.cpp collection_metadata.cpp三个文件中
3.delete操作的oplog新增fullfield字段，带原始信息。movechunk后的带frommigrate的不带